### PR TITLE
fix: Remove unused prismjs theme import

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,6 @@ import { Noto_Sans_JP, Permanent_Marker } from "next/font/google"
 import StyledComponentsRegistry from "@/lib/registry"
 import Providers from "@/components/Providers"
 import "modern-normalize/modern-normalize.css"
-import "prismjs/themes/prism-okaidia.css"
 import "font-awesome/css/font-awesome.css"
 
 const notoSansJP = Noto_Sans_JP({


### PR DESCRIPTION
## Summary
Remove unused prismjs theme import from the application layout that was left over from the migration.

## Changes
- Removed `prismjs/themes/prism-okaidia.css` import from `app/layout.tsx`
- This import is no longer needed after migrating to `rehype-pretty-code` for syntax highlighting

## Test Plan
- [x] Application builds successfully without the import
- [x] Syntax highlighting still works correctly with rehype-pretty-code
- [x] No console errors or warnings

🤖 Generated with [Claude Code](https://claude.ai/code)