### PR TITLE
fix: Reduce HTML file size for Cloudflare Pages deployment

### DIFF
--- a/lib/image-utils.ts
+++ b/lib/image-utils.ts
@@ -1,0 +1,52 @@
+import fs from "fs"
+import path from "path"
+
+export function ensureImageCopied(
+  sourceImagePath: string,
+  postSlug: string,
+  imageName: string
+): string {
+  const targetDir = path.join(
+    process.cwd(),
+    "public",
+    "images",
+    "posts",
+    postSlug
+  )
+  const targetPath = path.join(targetDir, imageName)
+  const publicPath = `/images/posts/${postSlug}/${imageName}`
+
+  if (!fs.existsSync(targetDir)) {
+    fs.mkdirSync(targetDir, { recursive: true })
+  }
+
+  if (!fs.existsSync(targetPath) && fs.existsSync(sourceImagePath)) {
+    fs.copyFileSync(sourceImagePath, targetPath)
+  }
+
+  return publicPath
+}
+
+export function processImagePath(
+  imageSrc: string,
+  postSlug: string,
+  postDir: string
+): string | undefined {
+  if (imageSrc.startsWith("http://") || imageSrc.startsWith("https://")) {
+    return imageSrc
+  }
+
+  const filename = imageSrc.startsWith("./") ? imageSrc.slice(2) : imageSrc
+  const sourceImagePath = path.join(postDir, filename)
+
+  if (fs.existsSync(sourceImagePath)) {
+    try {
+      return ensureImageCopied(sourceImagePath, postSlug, filename)
+    } catch (error) {
+      console.error(`Failed to copy image ${filename}:`, error)
+      return undefined
+    }
+  }
+
+  return undefined
+}


### PR DESCRIPTION
Replace base64-encoded images with external file references to fix Cloudflare Pages 25MB file size limit error. Previously, all images were embedded as base64 data URIs, causing index.html to exceed 35MB.

Changes:
- Add image-utils.ts to handle image file copying to public directory
- Update posts.ts to reference images via public URLs instead of base64
- Images now served from /images/posts/[slug]/ directory
- Reduced index.html from 36MB to 86KB (99.7% reduction)

This enables successful deployment to Cloudflare Pages while improving page load performance through browser caching and parallel downloads.

🤖 Generated with [Claude Code](https://claude.ai/code)