### PR TITLE
fix: Improve tile grid responsive design and aspect ratio

### DIFF
--- a/components/features/article/article-tile.tsx
+++ b/components/features/article/article-tile.tsx
@@ -17,7 +17,7 @@ const TileContainer = styled.article`
   border-radius: 8px;
   overflow: hidden;
   transition: all 0.2s ease;
-  height: 120px;
+  aspect-ratio: 1;
   display: flex;
   flex-direction: column;
 

--- a/components/ui/tile-grid.tsx
+++ b/components/ui/tile-grid.tsx
@@ -13,8 +13,12 @@ const GridWrapper = styled.div`
   max-width: ${(props) => props.theme.contentWidth}px;
   display: grid;
   gap: 0.5rem;
-  grid-template-columns: repeat(5, minmax(120px, 140px));
-  grid-auto-rows: 1fr;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  grid-auto-rows: auto;
+
+  @media (max-width: 767px) {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
 `
 
 const TileGrid: React.FC<Props> = ({ children }) => {


### PR DESCRIPTION
## Summary
- タイルグリッドのレスポンシブデザインを改善
- 固定の高さ指定からaspect-ratioベースの設計に変更
- モバイルビューでの列数を3列に調整

## Changes
- `components/features/article/article-tile.tsx`: 固定高さ(120px)から`aspect-ratio: 1`に変更
- `components/ui/tile-grid.tsx`: グリッドレイアウトを柔軟なレスポンシブデザインに変更
  - `minmax(120px, 140px)` → `minmax(0, 1fr)` で柔軟なサイズ調整
  - モバイルビュー(767px以下)で5列から3列に変更

## Test plan
- [ ] デスクトップビューでタイルグリッドが適切に表示されることを確認
- [ ] モバイルビューで3列のグリッドが正しく表示されることを確認
- [ ] タイルのアスペクト比が1:1で維持されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)