### PR TITLE
docs: CLAUDE.md を各ディレクトリに分割配置

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,91 +21,21 @@ pnpm test                # Run TypeScript type checking
 pnpm format              # Format code with Prettier
 ```
 
-## Architecture
+## Tech Stack
 
-This is a **Next.js 15** blog application built with modern web technologies. Key architectural points:
-
-### Tech Stack
 - **Next.js 15.5** with App Router (static site generation via `output: 'export'`)
 - **TypeScript 5.8** with strict mode
 - **styled-components 6.1** for CSS-in-JS with SSR support
 - **MDX 3.1** for blog post content with syntax highlighting
-- **rehype-pretty-code + shiki** for code syntax highlighting
 - **pnpm 9.12** as package manager
 
-### Directory Structure
+## Directory Structure
 
-#### `/app` - Next.js App Router pages and layouts
-- `layout.tsx` - Root layout with Noto Sans JP font configuration and providers
-- `page.tsx` - Homepage displaying blog post index
-- `[...slug]/page.tsx` - Dynamic catch-all route for blog posts (MDX rendering)
-- `profile/page.tsx` - Profile page
-
-#### `/components` - React components
-- `features/` - Feature-specific components
-  - `article/` - Blog post display components
-  - `profile/` - Profile page components
-- `layout/` - Layout components
-  - `navi-logo.tsx` - Logo component
-  - `navi-menu.tsx` - Navigation menu
-- `ui/` - Reusable UI components
-  - `display.tsx` - Display utilities
-  - `meta.tsx` - Meta tags component
-  - `section.tsx` - Section wrapper
-  - `slide-image.tsx` - Image slider
-  - `tile-grid.tsx` - Responsive grid layout
-- `icons/` - Icon components (FontAwesome integration)
-- `Providers.tsx` - Context providers (theme, styled-components registry)
-
-#### `/lib` - Core utilities
-- `posts.ts` - Blog post data fetching and processing (reads from `/content/posts/*/index.md`)
-- `image-utils.ts` - Image processing utilities (base64 conversion)
-- `registry.tsx` - styled-components SSR support
-- `ThemeContext.tsx` - Theme context for dark/light mode
-- `useDarkMode.ts` - Dark mode hook
-- `storage.ts` - Local storage utilities
-
-#### `/content/posts` - Blog posts in Markdown
-- Each post is a directory with `index.md` and optional images
-- Images are embedded as base64 data URIs during processing
-- Frontmatter schema: title, date, path, description, category, tags
-
-#### `/styles` - Global styles and theme configuration
-- `global-style.ts` - Global CSS styles
-- `theme.ts` - Theme definition (colors, typography, etc.)
-
-#### `/public` - Static assets
-- PWA manifest and icons
-- Favicon and app icons
-
-### Key Implementation Details
-
-1. **Static Site Generation**:
-   - Configured as static export (`output: 'export'`) with `trailingSlash: true`
-   - Images are unoptimized for static export compatibility
-   - Build errors temporarily ignored during migration (`ignoreBuildErrors: true`)
-
-2. **Blog Post Processing**:
-   - Posts stored in `/content/posts/[slug]/index.md`
-   - Images in post directories are converted to base64 data URIs via `image-utils.ts`
-   - MDX rendering with rehype-pretty-code for syntax highlighting
-   - Frontmatter parsing with gray-matter
-
-3. **Styling System**:
-   - styled-components with compiler support and SSR registry
-   - Dark/light theme support via ThemeContext
-   - Global styles in `/styles/global-style.ts`
-   - Noto Sans JP font for Japanese text (defined in `app/layout.tsx`)
-   - Modern normalize CSS (`modern-normalize`)
-
-4. **TypeScript Configuration**:
-   - Strict mode enabled
-   - Path alias `@/*` configured for imports
-   - Build errors temporarily ignored during Next.js migration
-   - ESLint configured with Next.js, React, and TypeScript rules
-
-5. **Dependencies**:
-   - **UI**: React 18.3, FontAwesome icons, react-share for social sharing
-   - **Content**: MDX, remark/rehype ecosystem, shiki for syntax highlighting
-   - **Utilities**: date-fns for date formatting, localforage for storage
-   - **Dev Tools**: ESLint, Prettier, textlint for Japanese text linting
+| Directory | Description | See |
+|-----------|-------------|-----|
+| `/app` | Next.js App Router pages and layouts | `app/CLAUDE.md` |
+| `/components` | React components (features, layout, ui, icons) | `components/CLAUDE.md` |
+| `/lib` | Core utilities and data fetching | `lib/CLAUDE.md` |
+| `/styles` | Global styles and theme configuration | `styles/CLAUDE.md` |
+| `/content` | Blog posts in Markdown | `content/CLAUDE.md` |
+| `/public` | Static assets (PWA manifest, icons) | - |

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -1,0 +1,38 @@
+# App Directory
+
+Next.js 15 App Router のページとレイアウトを管理するディレクトリ。
+
+## Structure
+
+```
+app/
+├── layout.tsx        # Root layout (フォント設定, Providers)
+├── page.tsx          # Homepage (ブログ記事一覧)
+├── [...slug]/
+│   └── page.tsx      # Dynamic route for blog posts (MDX rendering)
+└── profile/
+    └── page.tsx      # Profile page
+```
+
+## Key Patterns
+
+### Static Site Generation
+- `output: 'export'` で静的サイトとしてビルド
+- `trailingSlash: true` で末尾スラッシュを付与
+- `generateStaticParams` で動的ルートを事前生成
+
+### Root Layout (`layout.tsx`)
+- Noto Sans JP フォントの設定
+- `Providers` コンポーネントでテーマとstyled-componentsレジストリをラップ
+- メタデータの設定
+
+### Blog Post Route (`[...slug]/page.tsx`)
+- Catch-all route でネストされたパスに対応
+- `lib/posts.ts` からデータ取得
+- MDX を `@next/mdx` でレンダリング
+- rehype-pretty-code でシンタックスハイライト
+
+## Notes
+
+- 画像は `next/image` を使用するが、静的エクスポートのため `unoptimized: true`
+- ビルドエラーは一時的に `ignoreBuildErrors: true` で無視（マイグレーション中）

--- a/components/CLAUDE.md
+++ b/components/CLAUDE.md
@@ -1,0 +1,53 @@
+# Components Directory
+
+React コンポーネントを機能別に整理したディレクトリ。
+
+## Structure
+
+```
+components/
+├── Providers.tsx          # Context providers (theme, styled-components)
+├── features/              # Feature-specific components
+│   ├── article/           # Blog post display
+│   └── profile/           # Profile page
+├── layout/                # Layout components
+├── ui/                    # Reusable UI components
+└── icons/                 # Icon components
+```
+
+## Subdirectories
+
+### `features/`
+機能固有のコンポーネント。他の機能との結合度が高い。
+
+- **article/**: 記事表示関連 (`article.tsx`, `article-tile.tsx`, `article-info.tsx`, `article-index.tsx`)
+- **profile/**: プロフィールページ関連 (`profile-user.tsx`, `profile-work.tsx`, `profile-link.tsx`, `profile-others.tsx`, `thumbnail.tsx`)
+
+### `layout/`
+ページ全体のレイアウトを構成するコンポーネント。
+
+- `layout.tsx` - メインレイアウト
+- `navi.tsx`, `navi-logo.tsx`, `navi-menu.tsx` - ナビゲーション
+- `footer.tsx` - フッター
+
+### `ui/`
+再利用可能な汎用 UI コンポーネント。機能に依存しない。
+
+- `container.tsx`, `section.tsx`, `flex.tsx` - レイアウトユーティリティ
+- `heading.tsx`, `badge.tsx`, `time.tsx` - テキスト表示
+- `tile-grid.tsx`, `slide-image.tsx` - グリッド・画像表示
+- `meta.tsx` - メタタグ
+- `display.tsx`, `hr.tsx` - その他ユーティリティ
+
+### `icons/`
+FontAwesome ベースのアイコンコンポーネント。
+
+- `icon.tsx` - 基本アイコン
+- `icon-box.tsx` - ボックス付きアイコン
+- `icon-share.tsx` - シェアアイコン
+
+## Styling
+
+- **styled-components** を使用
+- テーマは `lib/ThemeContext.tsx` から取得
+- props で `theme` を受け取り、ダークモード対応

--- a/content/CLAUDE.md
+++ b/content/CLAUDE.md
@@ -1,0 +1,54 @@
+# Content Directory
+
+ブログ記事を Markdown 形式で管理するディレクトリ。
+
+## Structure
+
+```
+content/posts/
+└── [YYYY-MM-DD-slug]/
+    ├── index.md      # 記事本文 (Markdown + frontmatter)
+    └── *.jpg/png     # 記事内で使用する画像
+```
+
+## Frontmatter Schema
+
+```yaml
+---
+title: "記事タイトル"
+date: "YYYY-MM-DD"
+path: "/path/to/post"
+description: "記事の説明文"
+category: "カテゴリ名"
+tags:
+  - tag1
+  - tag2
+---
+```
+
+### Required Fields
+- `title`: 記事タイトル
+- `date`: 公開日 (YYYY-MM-DD 形式)
+- `path`: URL パス
+
+### Optional Fields
+- `description`: 記事の説明（OGP, メタタグ用）
+- `category`: カテゴリ
+- `tags`: タグの配列
+
+## Images
+
+- 記事と同じディレクトリに画像を配置
+- Markdown で相対パスで参照: `![alt](./image.jpg)`
+- ビルド時に base64 data URI に変換される
+
+## Linting
+
+```bash
+pnpm lint:text      # textlint で日本語テキストをチェック
+pnpm lint:textfix   # 自動修正
+```
+
+### textlint Rules
+- `.textlintrc` で設定
+- 日本語の技術文書向けルール

--- a/lib/CLAUDE.md
+++ b/lib/CLAUDE.md
@@ -1,0 +1,53 @@
+# Lib Directory
+
+コアユーティリティとデータフェッチングロジックを管理するディレクトリ。
+
+## Files
+
+### `posts.ts` - Blog Post Data
+ブログ記事の取得・処理を担当。
+
+```typescript
+// 主要な関数
+getAllPosts()      // 全記事を日付降順で取得
+getPostBySlug()    // スラッグから記事を取得
+```
+
+- `/content/posts/[slug]/index.md` から記事を読み込み
+- gray-matter で frontmatter をパース
+- 画像は base64 data URI に変換（`image-utils.ts` 使用）
+
+### `image-utils.ts` - Image Processing
+記事内の画像を base64 data URI に変換。
+
+- 静的エクスポート互換性のため
+- ローカル画像パスを検出して変換
+
+### `ThemeContext.tsx` - Theme Context
+ダーク/ライトモードのテーマ管理。
+
+```typescript
+// 使用方法
+const { theme, toggleTheme } = useTheme()
+```
+
+### `useDarkMode.ts` - Dark Mode Hook
+システム設定とローカルストレージからダークモード状態を管理。
+
+### `registry.tsx` - styled-components SSR
+styled-components の SSR サポート用レジストリ。
+
+### `storage.ts` - Local Storage
+localforage を使用したストレージユーティリティ。
+
+## Data Flow
+
+```
+content/posts/[slug]/index.md
+        ↓
+    posts.ts (getAllPosts / getPostBySlug)
+        ↓
+    image-utils.ts (base64 conversion)
+        ↓
+    app/[...slug]/page.tsx (MDX rendering)
+```

--- a/styles/CLAUDE.md
+++ b/styles/CLAUDE.md
@@ -1,0 +1,52 @@
+# Styles Directory
+
+グローバルスタイルとテーマ設定を管理するディレクトリ。
+
+## Files
+
+### `theme.ts` - Theme Definition
+ダーク/ライトモードのテーマ定義。
+
+```typescript
+// テーマ構造
+{
+  colors: {
+    background: string
+    text: string
+    primary: string
+    // ...
+  },
+  // その他のテーマ値
+}
+```
+
+- `light` と `dark` の2つのテーマを定義
+- `lib/ThemeContext.tsx` から使用
+
+### `global-style.ts` - Global Styles
+styled-components の `createGlobalStyle` でグローバルスタイルを定義。
+
+- modern-normalize でブラウザスタイルをリセット
+- 基本的なタイポグラフィ設定
+- リンクスタイル
+- コードブロックのスタイル
+
+## Usage
+
+```typescript
+// Providers.tsx で適用
+import { GlobalStyle } from '@/styles/global-style'
+import { lightTheme, darkTheme } from '@/styles/theme'
+
+<ThemeProvider theme={isDark ? darkTheme : lightTheme}>
+  <GlobalStyle />
+  {children}
+</ThemeProvider>
+```
+
+## Dark Mode
+
+1. `lib/useDarkMode.ts` でシステム設定を検出
+2. `lib/ThemeContext.tsx` で状態管理
+3. `styles/theme.ts` からテーマ値を取得
+4. styled-components の `ThemeProvider` でコンポーネントに提供


### PR DESCRIPTION
- ルート CLAUDE.md を簡略化（コマンド、技術スタック、構造概要のみ）
- app/CLAUDE.md: App Router 固有の情報（ルーティング、SSG設定）
- components/CLAUDE.md: コンポーネント設計原則、ディレクトリ構造
- lib/CLAUDE.md: ユーティリティ関数、データフロー
- styles/CLAUDE.md: テーマ設定、ダークモード対応
- content/CLAUDE.md: Frontmatter スキーマ、画像配置ルール