### PR TITLE
Add product images to latest articles

### DIFF
--- a/content/posts/2025-09-10-home-assistant-setup-log/index.md
+++ b/content/posts/2025-09-10-home-assistant-setup-log/index.md
@@ -37,6 +37,8 @@ Home Assistant OS をインストールするマシンとして、省電力性�
 - ネットワーク: 2.5Gbps Ethernet ポート x2, Wi-Fi 6
 - 特徴: 低消費電力でありながら、Home Assistant および多数のアドオンを快適に動作させるのに十分な性能を持っています。ファンレス設計に近く、非常に静かです。
 
+https://www.amazon.co.jp/dp/B0D5XNYVHN
+
 初期設定のポイント
 基本設定ファイル（`configuration.yaml`）の構成：
 
@@ -125,6 +127,8 @@ Bluetooth 対応デバイスを Home Assistant に接続するための Proxy �
 - Flash: 8MB
 - 特徴: 小型ながら強力な ESP32-S3 を搭載し、Bluetooth プロキシとして安定した動作が期待できます。
 
+https://www.switch-science.com/products/8778
+
 ```yaml
 esphome:
   name: m5stack-atom3-lite
@@ -171,6 +175,8 @@ M5Stack Atom Echo（音声アシスタント）
 - マイク: SPM1423 (PDM)
 - スピーカー: 0.5W
 - 特徴: マイクとスピーカーを内蔵した超小型の ESP32 開発ボード。Home Assistant の音声アシスタントを安価に構築するのに最適です。
+
+https://www.switch-science.com/products/6347
 
 ```yaml
 esphome:

--- a/content/posts/2025-12-15-2025-purchases/index.md
+++ b/content/posts/2025-12-15-2025-purchases/index.md
@@ -49,7 +49,7 @@ https://ja.aliexpress.com/item/1005009658413745.html
 
 土壌の水分量と温度をリアルタイムでアプリから確認できます。IP67 防水で屋外でも使用可能。Zigbee 接続なので Home Assistant との連携もスムーズです。Tuya 水タイマーと組み合わせれば自動灌漑システムも構築できます。観葉植物を枯らしがちな人、ベランダ菜園を始めたい人におすすめ。
 
-https://www.aliexpress.com/w/wholesale-tuya-soil-sensor.html
+https://ja.aliexpress.com/item/1005009507027327.html
 
 ## Bambu Lab A1 mini
 

--- a/content/posts/2025-12-15-2025-purchases/index.md
+++ b/content/posts/2025-12-15-2025-purchases/index.md
@@ -41,7 +41,7 @@ https://www.amazon.co.jp/dp/B0DPHFMN6V
 
 Snapdragon 8 Gen 3 搭載で AnTuTu 200 万点超えのハイエンドタブレットが 3 万円台で買えるのは破格。11.1 インチ 3K ディスプレイは 144Hz 対応で、動画視聴やゲームが快適。スタイラスペン付属で 8192 段階の筆圧検知にも対応しています。中国版ですが Google Play も導入可能。壁掛けダッシュボードとして使っています。
 
-https://www.aliexpress.com/w/wholesale-lenovo-xiaoxin-pad-pro.html
+https://ja.aliexpress.com/item/1005009658413745.html
 
 ## Tuya スマート Zigbee 土壌センサー
 

--- a/content/posts/2025-12-15-2025-purchases/index.md
+++ b/content/posts/2025-12-15-2025-purchases/index.md
@@ -17,7 +17,7 @@ tags:
 
 180°開口デザインで中身が一目瞭然。開くとペン立てのように自立するので、デスクに置いたまま必要なものをサッと取り出せます。1200D ポリエステル素材で撥水加工もあり、急な雨でも安心。YKK 製ファスナーでスムーズに開閉できるのも地味に嬉しい。充電器、ケーブル、モバイルバッテリーなど、散らかりがちな小物をまとめたい人におすすめです。
 
-→ [Amazon](https://www.amazon.co.jp/dp/B0B766Y3ZQ)
+https://www.amazon.co.jp/dp/B0B766Y3ZQ
 
 ## Seagate BarraCuda 24TB (ST24000DM001)
 
@@ -25,7 +25,7 @@ tags:
 
 24TB という大容量ながら、GB あたり約 2.3 円とコスパ抜群。CMR 方式で書き込み性能も安定しており、NAS での常時稼働にも向いています。7200RPM、512MB キャッシュで転送速度も十分。動画や写真のアーカイブ、バックアップ用途に最適です。Western Digital の WD Blue が最大 12TB なので、大容量を求めるなら現状これ一択。
 
-→ [Amazon](https://www.amazon.co.jp/dp/B0DVBRYGSY)
+https://www.amazon.co.jp/dp/B0DVBRYGSY
 
 ## Beelink Mini S13
 
@@ -33,7 +33,7 @@ tags:
 
 Intel N150 搭載で TDP わずか 25W の省電力設計。Home Assistant やホームサーバー用途には十分な性能です。16GB RAM、512GB SSD、デュアル HDMI で 4K 出力にも対応。手のひらサイズでファンが静かです。24 時間稼働させても電気代が気になりません。
 
-→ [Amazon](https://www.amazon.co.jp/dp/B0DPHFMN6V)
+https://www.amazon.co.jp/dp/B0DPHFMN6V
 
 ## Lenovo Xiaoxin Pad Pro GT 11.1
 
@@ -41,7 +41,7 @@ Intel N150 搭載で TDP わずか 25W の省電力設計。Home Assistant や�
 
 Snapdragon 8 Gen 3 搭載で AnTuTu 200 万点超えのハイエンドタブレットが 3 万円台で買えるのは破格。11.1 インチ 3K ディスプレイは 144Hz 対応で、動画視聴やゲームが快適。スタイラスペン付属で 8192 段階の筆圧検知にも対応しています。中国版ですが Google Play も導入可能。壁掛けダッシュボードとして使っています。
 
-→ [AliExpress](https://www.aliexpress.com/w/wholesale-lenovo-xiaoxin-pad-pro.html)
+https://www.aliexpress.com/w/wholesale-lenovo-xiaoxin-pad-pro.html
 
 ## Tuya スマート Zigbee 土壌センサー
 
@@ -49,7 +49,7 @@ Snapdragon 8 Gen 3 搭載で AnTuTu 200 万点超えのハイエンドタブレ�
 
 土壌の水分量と温度をリアルタイムでアプリから確認できます。IP67 防水で屋外でも使用可能。Zigbee 接続なので Home Assistant との連携もスムーズです。Tuya 水タイマーと組み合わせれば自動灌漑システムも構築できます。観葉植物を枯らしがちな人、ベランダ菜園を始めたい人におすすめ。
 
-→ [AliExpress](https://www.aliexpress.com/w/wholesale-tuya-soil-sensor.html)
+https://www.aliexpress.com/w/wholesale-tuya-soil-sensor.html
 
 ## Bambu Lab A1 mini
 
@@ -57,7 +57,7 @@ Snapdragon 8 Gen 3 搭載で AnTuTu 200 万点超えのハイエンドタブレ�
 
 20 分でセットアップ完了、全自動キャリブレーションで初心者でも安心。印刷速度は最大 500mm/s と爆速で、アクティブモーターノイズキャンセリングにより 48dB 以下の静音動作を実現。光造形と違って後処理が楽なので、思いついたらすぐ作れる気軽さがあります。AMS lite を追加すれば 4 色マルチカラー印刷も可能。3 万円以下で買える入門機としては最高峰です。
 
-→ [Bambu Lab 公式](https://jp.store.bambulab.com/products/a1-mini)
+https://jp.store.bambulab.com/products/a1-mini
 
 ## New Balance Fresh Foam X More v4
 
@@ -65,7 +65,7 @@ Snapdragon 8 Gen 3 搭載で AnTuTu 200 万点超えのハイエンドタブレ�
 
 シリーズ史上最も厚く、柔らかい Fresh Foam X ミッドソールを搭載。厚底なのに安定感があり、長時間歩いても足が疲れにくいです。つま先がそり上がったロッカー構造で、自然と足が前に出る感覚。通勤からジョギングまで使える万能シューズです。デザインも落ち着いていて普段履きしやすいのもポイント。
 
-→ [ニューバランス公式](https://shop.newbalance.jp/shop/g/gMMORWS4)
+https://shop.newbalance.jp/shop/g/gMMORWS4
 
 ## NVIDIA GeForce RTX 5070 Ti
 
@@ -73,4 +73,4 @@ Snapdragon 8 Gen 3 搭載で AnTuTu 200 万点超えのハイエンドタブレ�
 
 Blackwell アーキテクチャ搭載で、DLSS 4 によるフレーム生成が強力。16GB GDDR7 メモリで VRAM 不足に悩まされることもなくなりました。4K ゲーミングも快適、AI 画像生成も爆速。RTX 3070 からの乗り換えですが、あらゆる場面で余裕を感じます。消費電力 300W は気になりますが、性能を考えれば妥当なところ。
 
-→ [Amazon](https://www.amazon.co.jp/dp/B0DX791JB5)
+https://www.amazon.co.jp/dp/B0DX791JB5

--- a/content/posts/2025-12-15-2025-purchases/index.md
+++ b/content/posts/2025-12-15-2025-purchases/index.md
@@ -59,7 +59,7 @@ https://ja.aliexpress.com/item/1005009507027327.html
 
 https://jp.store.bambulab.com/products/a1-mini
 
-## New Balance Fresh Foam X More v4
+## New Balance Fresh Foam X More v5
 
 クッション性が良くて出社が楽しくなりました。
 

--- a/content/posts/2025-12-15-2025-purchases/index.md
+++ b/content/posts/2025-12-15-2025-purchases/index.md
@@ -65,7 +65,7 @@ https://jp.store.bambulab.com/products/a1-mini
 
 シリーズ史上最も厚く、柔らかい Fresh Foam X ミッドソールを搭載。厚底なのに安定感があり、長時間歩いても足が疲れにくいです。つま先がそり上がったロッカー構造で、自然と足が前に出る感覚。通勤からジョギングまで使える万能シューズです。デザインも落ち着いていて普段履きしやすいのもポイント。
 
-https://shop.newbalance.jp/shop/g/gMMORLJ5
+https://www.amazon.co.jp/dp/B0D3142WBV
 
 ## NVIDIA GeForce RTX 5070 Ti
 

--- a/content/posts/2025-12-15-2025-purchases/index.md
+++ b/content/posts/2025-12-15-2025-purchases/index.md
@@ -65,7 +65,7 @@ https://jp.store.bambulab.com/products/a1-mini
 
 シリーズ史上最も厚く、柔らかい Fresh Foam X ミッドソールを搭載。厚底なのに安定感があり、長時間歩いても足が疲れにくいです。つま先がそり上がったロッカー構造で、自然と足が前に出る感覚。通勤からジョギングまで使える万能シューズです。デザインも落ち着いていて普段履きしやすいのもポイント。
 
-https://shop.newbalance.jp/shop/g/gMMORWS4
+https://shop.newbalance.jp/shop/g/gMMORLJ5
 
 ## NVIDIA GeForce RTX 5070 Ti
 

--- a/lib/link-card.ts
+++ b/lib/link-card.ts
@@ -1,0 +1,104 @@
+import ogs from "open-graph-scraper"
+
+export interface OgpData {
+  title: string
+  description: string
+  image: string
+  url: string
+  siteName: string
+}
+
+const ogpCache = new Map<string, OgpData>()
+
+export async function fetchOgp(url: string): Promise<OgpData | null> {
+  if (ogpCache.has(url)) {
+    return ogpCache.get(url)!
+  }
+
+  try {
+    const { result } = await ogs({
+      url,
+      timeout: 10000,
+      fetchOptions: {
+        headers: {
+          "user-agent":
+            "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
+        },
+      },
+    })
+
+    if (result.success) {
+      const ogpData: OgpData = {
+        title: result.ogTitle || result.dcTitle || extractTitleFromUrl(url),
+        description: result.ogDescription || result.dcDescription || "",
+        image: result.ogImage?.[0]?.url || "",
+        url: result.ogUrl || url,
+        siteName: result.ogSiteName || extractDomain(url),
+      }
+      ogpCache.set(url, ogpData)
+      return ogpData
+    }
+  } catch (error) {
+    console.warn(`Failed to fetch OGP for ${url}:`, error)
+  }
+
+  // Fallback: return basic data from URL
+  const fallbackData: OgpData = {
+    title: extractTitleFromUrl(url),
+    description: "",
+    image: "",
+    url,
+    siteName: extractDomain(url),
+  }
+  ogpCache.set(url, fallbackData)
+  return fallbackData
+}
+
+function extractDomain(url: string): string {
+  try {
+    const hostname = new URL(url).hostname
+    return hostname.replace(/^www\./, "")
+  } catch {
+    return url
+  }
+}
+
+function extractTitleFromUrl(url: string): string {
+  try {
+    const pathname = new URL(url).pathname
+    const lastSegment = pathname.split("/").filter(Boolean).pop()
+    return lastSegment || extractDomain(url)
+  } catch {
+    return url
+  }
+}
+
+export function generateLinkCardHtml(ogp: OgpData): string {
+  const imageHtml = ogp.image
+    ? `<div class="link-card-image"><img src="${escapeHtml(
+        ogp.image
+      )}" alt="" loading="lazy" /></div>`
+    : `<div class="link-card-image link-card-no-image"><span>${escapeHtml(
+        ogp.siteName.charAt(0).toUpperCase()
+      )}</span></div>`
+
+  return `<a href="${escapeHtml(
+    ogp.url
+  )}" class="link-card" target="_blank" rel="noopener noreferrer">
+  ${imageHtml}
+  <div class="link-card-content">
+    <div class="link-card-title">${escapeHtml(ogp.title)}</div>
+    <div class="link-card-description">${escapeHtml(ogp.description)}</div>
+    <div class="link-card-site">${escapeHtml(ogp.siteName)}</div>
+  </div>
+</a>`
+}
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;")
+}

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -6,6 +6,7 @@ import remarkParse from "remark-parse"
 import remarkRehype from "remark-rehype"
 import rehypeStringify from "rehype-stringify"
 import rehypePrettyCode from "rehype-pretty-code"
+import rehypeLinkCard from "./rehype-link-card"
 import { processImagePath } from "./image-utils"
 
 const postsDirectory = path.join(process.cwd(), "content/posts")
@@ -128,6 +129,7 @@ export async function getPostBySlug(slug: string): Promise<PostData | null> {
       keepBackground: true,
       defaultLang: "plaintext",
     })
+    .use(rehypeLinkCard)
     .use(rehypeStringify)
     .process(contentWithUrls)
 

--- a/lib/rehype-link-card.ts
+++ b/lib/rehype-link-card.ts
@@ -1,0 +1,75 @@
+import { visit } from "unist-util-visit"
+import type { Root, Element, Text } from "hast"
+import { fromHtml } from "hast-util-from-html"
+import { fetchOgp, generateLinkCardHtml } from "./link-card"
+
+const URL_REGEX = /^https?:\/\/[^\s]+$/
+
+export default function rehypeLinkCard() {
+  return async (tree: Root) => {
+    const nodesToReplace: { parent: Element; index: number; url: string }[] = []
+
+    visit(tree, "element", (node: Element, index, parent) => {
+      // <p> タグで、中身がテキストのみのURLの場合を検出
+      if (
+        node.tagName === "p" &&
+        node.children.length === 1 &&
+        node.children[0].type === "text"
+      ) {
+        const text = (node.children[0] as Text).value.trim()
+        if (URL_REGEX.test(text)) {
+          nodesToReplace.push({
+            parent: parent as Element,
+            index: index as number,
+            url: text,
+          })
+        }
+      }
+
+      // <p> タグ内の <a> タグで、テキストがURLと同じ場合も検出
+      // 例: <p><a href="https://...">https://...</a></p>
+      if (
+        node.tagName === "p" &&
+        node.children.length === 1 &&
+        (node.children[0] as Element).tagName === "a"
+      ) {
+        const anchor = node.children[0] as Element
+        const href = anchor.properties?.href as string
+        if (
+          href &&
+          anchor.children.length === 1 &&
+          anchor.children[0].type === "text"
+        ) {
+          const text = (anchor.children[0] as Text).value.trim()
+          if (text === href && URL_REGEX.test(href)) {
+            nodesToReplace.push({
+              parent: parent as Element,
+              index: index as number,
+              url: href,
+            })
+          }
+        }
+      }
+    })
+
+    // OGP情報を並列で取得
+    const ogpResults = await Promise.all(
+      nodesToReplace.map(async ({ url }) => {
+        const ogp = await fetchOgp(url)
+        return { url, ogp }
+      })
+    )
+
+    // ノードを置換（逆順で処理してインデックスがずれないようにする）
+    for (let i = nodesToReplace.length - 1; i >= 0; i--) {
+      const { parent, index } = nodesToReplace[i]
+      const { ogp } = ogpResults[i]
+
+      if (ogp && parent.children) {
+        const html = generateLinkCardHtml(ogp)
+        const fragment = fromHtml(html, { fragment: true })
+        parent.children.splice(index, 1, ...(fragment.children as Element[]))
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,9 +13,11 @@
     "date-fns": "^4.1.0",
     "font-awesome": "4.7.0",
     "gray-matter": "^4.0.3",
+    "hast-util-from-html": "^2.0.3",
     "localforage": "1.10.0",
     "modern-normalize": "3.0.1",
     "next": "^15.5.3",
+    "open-graph-scraper": "^6.11.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-helmet": "6.1.0",
@@ -28,10 +30,12 @@
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.2",
     "shiki": "^3.13.0",
-    "unified": "^11.0.5"
+    "unified": "^11.0.5",
+    "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {
     "@babel/eslint-parser": "7.27.0",
+    "@types/hast": "^3.0.4",
     "@types/node": "^22.7.5",
     "@types/react": "^18.3.11",
     "@types/react-helmet": "6.1.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
+      hast-util-from-html:
+        specifier: ^2.0.3
+        version: 2.0.3
       localforage:
         specifier: 1.10.0
         version: 1.10.0
@@ -44,6 +47,9 @@ importers:
       next:
         specifier: ^15.5.3
         version: 15.5.9(@babel/core@7.27.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      open-graph-scraper:
+        specifier: ^6.11.0
+        version: 6.11.0
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -83,10 +89,16 @@ importers:
       unified:
         specifier: ^11.0.5
         version: 11.0.5
+      unist-util-visit:
+        specifier: ^5.0.0
+        version: 5.0.0
     devDependencies:
       '@babel/eslint-parser':
         specifier: 7.27.0
         version: 7.27.0(@babel/core@7.27.7)(eslint@8.57.1)
+      '@types/hast':
+        specifier: ^3.0.4
+        version: 3.0.4
       '@types/node':
         specifier: ^22.7.5
         version: 22.16.0
@@ -1317,6 +1329,9 @@ packages:
     resolution: {integrity: sha512-nfDwkulwiZYQIGwxdy0RUmowMhKcFVcYXUU7m4QlKYim1rUtg83xm2yjZ40QjDuc291AJjjeSc9b++AWHSgSHw==}
     engines: {node: '>=18'}
 
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
   boundary@1.0.1:
     resolution: {integrity: sha512-AaLhxHwYVh55iOTJncV3DE5o7RakEUSSj64XXEWRTiIhlp7aDI8qR0vY/k8Uw0Z234VjZi/iG/WxfrvqYPUCww==}
 
@@ -1413,8 +1428,18 @@ packages:
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
+  chardet@2.1.1:
+    resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+
   charenc@0.0.2:
     resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
+
+  cheerio-select@2.1.0:
+    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
+
+  cheerio@1.1.2:
+    resolution: {integrity: sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==}
+    engines: {node: '>=20.18.1'}
 
   chrome-trace-event@1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
@@ -1504,8 +1529,15 @@ packages:
     resolution: {integrity: sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==}
     engines: {node: '>=4'}
 
+  css-select@5.2.2:
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
   css-to-react-native@3.2.0:
     resolution: {integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==}
+
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
@@ -1636,6 +1668,19 @@ packages:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
   doublearray@0.0.2:
     resolution: {integrity: sha512-aw55FtZzT6AmiamEj2kvmR6BuFqvYgKZUkfQ7teqVRNqD5UE0rw8IeW/3gieHNKQ5sPuDKlljWEn4bzv5+1bHw==}
 
@@ -1662,9 +1707,16 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
+  encoding-sniffer@0.2.1:
+    resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
+
   enhanced-resolve@5.18.4:
     resolution: {integrity: sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==}
     engines: {node: '>=10.13.0'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
@@ -2255,9 +2307,16 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
+  htmlparser2@10.0.0:
+    resolution: {integrity: sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   iconv-lite@0.7.1:
     resolution: {integrity: sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw==}
@@ -3025,6 +3084,9 @@ packages:
     resolution: {integrity: sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -3089,6 +3151,10 @@ packages:
   oniguruma-to-es@4.3.4:
     resolution: {integrity: sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA==}
 
+  open-graph-scraper@6.11.0:
+    resolution: {integrity: sha512-KkO3qMMzJj9KYGtCl19dRtncb+RuBiG/P9BgukcAG4p2w9wSAWTE90vL6/xqth1K9ThkYF/+xfTGrVvU79TJtQ==}
+    engines: {node: '>=20.0.0'}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -3124,6 +3190,12 @@ packages:
 
   parse-numeric-range@1.3.0:
     resolution: {integrity: sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==}
+
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
+
+  parse5-parser-stream@7.1.2:
+    resolution: {integrity: sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==}
 
   parse5@5.1.1:
     resolution: {integrity: sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==}
@@ -3987,6 +4059,10 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici@7.16.0:
+    resolution: {integrity: sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==}
+    engines: {node: '>=20.18.1'}
+
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
     engines: {node: '>=18'}
@@ -4111,6 +4187,14 @@ packages:
     peerDependenciesMeta:
       webpack-cli:
         optional: true
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
 
   which-boxed-primitive@1.0.2:
     resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}
@@ -5601,6 +5685,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  boolbase@1.0.0: {}
+
   boundary@1.0.1: {}
 
   boundary@2.0.0: {}
@@ -5702,7 +5788,32 @@ snapshots:
 
   character-reference-invalid@2.0.1: {}
 
+  chardet@2.1.1: {}
+
   charenc@0.0.2: {}
+
+  cheerio-select@2.1.0:
+    dependencies:
+      boolbase: 1.0.0
+      css-select: 5.2.2
+      css-what: 6.2.2
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+
+  cheerio@1.1.2:
+    dependencies:
+      cheerio-select: 2.1.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      encoding-sniffer: 0.2.1
+      htmlparser2: 10.0.0
+      parse5: 7.3.0
+      parse5-htmlparser2-tree-adapter: 7.1.0
+      parse5-parser-stream: 7.1.2
+      undici: 7.16.0
+      whatwg-mimetype: 4.0.0
 
   chrome-trace-event@1.0.4:
     optional: true
@@ -5780,11 +5891,21 @@ snapshots:
 
   css-color-keywords@1.0.0: {}
 
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
   css-to-react-native@3.2.0:
     dependencies:
       camelize: 1.0.1
       css-color-keywords: 1.0.0
       postcss-value-parser: 4.2.0
+
+  css-what@6.2.2: {}
 
   csstype@3.1.3: {}
 
@@ -5897,6 +6018,24 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
   doublearray@0.0.2: {}
 
   dunder-proto@1.0.1:
@@ -5917,11 +6056,18 @@ snapshots:
 
   encodeurl@2.0.0: {}
 
+  encoding-sniffer@0.2.1:
+    dependencies:
+      iconv-lite: 0.6.3
+      whatwg-encoding: 3.1.1
+
   enhanced-resolve@5.18.4:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.0
     optional: true
+
+  entities@4.5.0: {}
 
   entities@6.0.1: {}
 
@@ -6944,6 +7090,13 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
+  htmlparser2@10.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 6.0.1
+
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -6951,6 +7104,10 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   iconv-lite@0.7.1:
     dependencies:
@@ -7933,6 +8090,10 @@ snapshots:
       semver: 7.7.2
       validate-npm-package-license: 3.0.4
 
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
+
   object-assign@4.1.1: {}
 
   object-inspect@1.13.2: {}
@@ -8009,6 +8170,13 @@ snapshots:
       regex: 6.0.1
       regex-recursion: 6.0.2
 
+  open-graph-scraper@6.11.0:
+    dependencies:
+      chardet: 2.1.1
+      cheerio: 1.1.2
+      iconv-lite: 0.7.1
+      undici: 7.16.0
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -8064,6 +8232,15 @@ snapshots:
       type-fest: 4.41.0
 
   parse-numeric-range@1.3.0: {}
+
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    dependencies:
+      domhandler: 5.0.3
+      parse5: 7.3.0
+
+  parse5-parser-stream@7.1.2:
+    dependencies:
+      parse5: 7.3.0
 
   parse5@5.1.1: {}
 
@@ -9268,6 +9445,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici@7.16.0: {}
+
   unicorn-magic@0.1.0: {}
 
   unified@11.0.5:
@@ -9472,6 +9651,12 @@ snapshots:
       - esbuild
       - uglify-js
     optional: true
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
 
   which-boxed-primitive@1.0.2:
     dependencies:

--- a/styles/global-style.ts
+++ b/styles/global-style.ts
@@ -120,9 +120,11 @@ const GlobalStyles = createGlobalStyle`
       overflow: hidden;
 
       img {
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
+        max-width: 100%;
+        max-height: 100%;
+        width: auto;
+        height: auto;
+        object-fit: contain;
         margin: 0;
       }
     }

--- a/styles/global-style.ts
+++ b/styles/global-style.ts
@@ -90,6 +90,105 @@ const GlobalStyles = createGlobalStyle`
       font-size: ${(props) => `${props.theme.fontSizeSmall}rem`};
       font-family: 'Consolas', 'Monaco', 'Andale Mono', 'Ubuntu Mono', monospace;
     }
+
+    /* Link card styles */
+    .link-card {
+      display: flex;
+      align-items: stretch;
+      border: 1px solid ${(props) => props.theme.colorBorder};
+      border-radius: 8px;
+      overflow: hidden;
+      margin: 1.5rem 0;
+      text-decoration: none;
+      color: inherit;
+      transition: box-shadow 0.2s ease, border-color 0.2s ease;
+
+      &:hover {
+        border-color: ${(props) => props.theme.colorMain};
+        box-shadow: 0 2px 8px ${(props) => props.theme.colorShadow};
+      }
+    }
+
+    .link-card-image {
+      flex-shrink: 0;
+      width: 120px;
+      min-height: 100px;
+      background-color: ${(props) => props.theme.colorBorder};
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      overflow: hidden;
+
+      img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        margin: 0;
+      }
+    }
+
+    .link-card-no-image {
+      span {
+        font-size: 2rem;
+        font-weight: bold;
+        color: ${(props) => props.theme.colorSub};
+      }
+    }
+
+    .link-card-content {
+      flex: 1;
+      padding: 0.75rem 1rem;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      min-width: 0;
+    }
+
+    .link-card-title {
+      font-weight: ${(props) => props.theme.fontWeightBold};
+      font-size: ${(props) => `${props.theme.fontSize}rem`};
+      line-height: 1.4;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+      margin-bottom: 0.25rem;
+    }
+
+    .link-card-description {
+      font-size: ${(props) => `${props.theme.fontSizeSmall}rem`};
+      color: ${(props) => props.theme.colorSub};
+      line-height: 1.4;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+      margin-bottom: 0.25rem;
+    }
+
+    .link-card-site {
+      font-size: ${(props) => `${props.theme.fontSizeSmall}rem`};
+      color: ${(props) => props.theme.colorSub};
+    }
+
+    @media (max-width: 480px) {
+      .link-card-image {
+        width: 80px;
+        min-height: 80px;
+      }
+
+      .link-card-content {
+        padding: 0.5rem 0.75rem;
+      }
+
+      .link-card-title {
+        font-size: ${(props) => `${props.theme.fontSizeSmall}rem`};
+      }
+
+      .link-card-description {
+        -webkit-line-clamp: 1;
+      }
+    }
   }
 `
 export default GlobalStyles

--- a/styles/global-style.ts
+++ b/styles/global-style.ts
@@ -120,11 +120,9 @@ const GlobalStyles = createGlobalStyle`
       overflow: hidden;
 
       img {
-        max-width: 100%;
-        max-height: 100%;
-        width: auto;
-        height: auto;
-        object-fit: contain;
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
         margin: 0;
       }
     }


### PR DESCRIPTION
- rehype-link-card プラグインを作成し、単独行のURLを自動でリンクカードに変換
- OGP情報（タイトル・説明・画像）をビルド時に取得してカード表示
- 画像を左配置したレスポンシブなカードデザインを追加
- 買ってよかったもの2025の記事でリンクカード形式に対応