### PR TITLE
feat: 記事詳細ページに OGP タグを追加

### DIFF
--- a/app/[...slug]/page.tsx
+++ b/app/[...slug]/page.tsx
@@ -21,8 +21,8 @@ export async function generateMetadata({
   params,
 }: PostPageProps): Promise<Metadata> {
   const { slug } = await params
-  const path = "/" + slug.join("/")
-  const post = await getPostByPath(path)
+  const postPath = "/" + slug.join("/")
+  const post = await getPostByPath(postPath)
 
   if (!post) {
     return {
@@ -30,9 +30,33 @@ export async function generateMetadata({
     }
   }
 
+  const siteUrl = "https://jaxx2104.info"
+  const title = `${post.title} | jaxx2104.info`
+  const description = post.content?.split(/\n/)[0] || ""
+  const url = `${siteUrl}${post.path}`
+  const imageUrl = post.thumbnail ? `${siteUrl}${post.thumbnail}` : undefined
+
   return {
-    title: `${post.title} | jaxx2104.info`,
-    description: post.content?.split(/\n/)[0],
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: "jaxx2104.info",
+      type: "article",
+      ...(imageUrl && {
+        images: [{ url: imageUrl }],
+      }),
+    },
+    twitter: {
+      card: imageUrl ? "summary_large_image" : "summary",
+      title,
+      description,
+      ...(imageUrl && {
+        images: [imageUrl],
+      }),
+    },
   }
 }
 

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -97,6 +97,14 @@ export async function getPostBySlug(slug: string): Promise<PostData | null> {
   const fileContents = fs.readFileSync(fullPath, "utf8")
   const { data, content } = matter(fileContents)
 
+  // Extract first image for thumbnail
+  let thumbnail: string | undefined
+  const imageMatch = content.match(/!\[.*?\]\(([^)]+)\)/)
+  if (imageMatch) {
+    const imageSrc = imageMatch[1]
+    thumbnail = processImagePath(imageSrc, slug, fullPath.replace("/index.md", ""))
+  }
+
   // Convert images to public URLs
   const postDir = path.join(postsDirectory, slug)
   let contentWithUrls = content
@@ -143,6 +151,7 @@ export async function getPostBySlug(slug: string): Promise<PostData | null> {
     tags: data.tags,
     content,
     html: processedContent.toString(),
+    thumbnail,
   }
 }
 


### PR DESCRIPTION
- OpenGraph メタタグ（title, description, url, site_name, type, image）を追加
- Twitter Card メタタグを追加（画像ありの場合は summary_large_image）
- getPostBySlug にサムネイル取得処理を追加