### PR TITLE
ci: prepare workflow triggers for master → main rename

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,12 +2,12 @@ name: Lint
 on:
   push:
     branches:
-      - master
+      - main
       - staging
       - develop
   pull_request:
     branches:
-      - master
+      - main
       - staging
       - develop
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,12 +2,12 @@ name: Test
 on:
   push:
     branches:
-      - master
+      - main
       - staging
       - develop
   pull_request:
     branches:
-      - master
+      - main
       - staging
       - develop
 jobs:


### PR DESCRIPTION
## Summary

- Replace `master` with `main` in the trigger branch lists of `.github/workflows/lint.yml` and `.github/workflows/test.yml` so that workflows keep firing once the default branch is renamed.
- This must merge **before** renaming the default branch on GitHub. After this is merged, the rename can happen via `gh api -X POST /repos/jaxx2104/blog/branches/master/rename -f new_name=main`, which will also auto-update the base of any open PRs.

No runtime changes; CI configuration only.

## Test plan

- [ ] CI Lint and Test workflows still trigger on this PR (against the current `master` base)
- [ ] After merge + rename, a follow-up push to `main` triggers both workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)