### PR TITLE
docs: codify build-artifact and type pitfalls from velite phase 0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,3 +39,32 @@ pnpm format              # Format code with Prettier
 | `/styles` | Global styles and theme configuration | `styles/CLAUDE.md` |
 | `/content` | Blog posts in Markdown | `content/CLAUDE.md` |
 | `/public` | Static assets (PWA manifest, icons) | - |
+
+## Build Artifacts and Type Pitfalls
+
+Hard-won lessons from the Velite migration (Phase 0). Read these before
+touching `velite.config.ts`, the generated `.velite/` content layer, the
+project tsconfig, or anything that runs in CI.
+
+- Do not seal a value with `as const` if it is going to be passed as a
+  function argument to an external SDK. SDK parameter types are almost
+  always mutable (`Array<T>`, plain object), and the `readonly` form
+  produced by `as const` fails to assign with TS2322. Velite's
+  `MarkdownOptions.rehypePlugins` is the canonical example in this repo.
+- For tools that emit a `.d.ts` next to their generated runtime (Velite,
+  contentlayer, tRPC, zod-to-* and friends), add the source files those
+  declarations re-import to tsconfig's `exclude`, not just remove them
+  from `include`. Generated `import type` statements pull excluded
+  sources back in transitively and re-surface the error you tried to
+  suppress.
+- If a tsconfig-included script depends on a build artifact (e.g.
+  `scripts/verify-velite.ts` importing `.velite/index.js`), the CI
+  pipeline must run the generator before tsc. Local runs hide this
+  failure because the previous build's artifact is still on disk —
+  reproduce the CI environment with `rm -rf <output-dir> && pnpm test`
+  before pushing.
+- When a young OSS dependency's documented behavior is unclear, grep
+  `node_modules/<lib>/dist/` directly instead of arguing from README
+  excerpts. Velite's `s.path()` defaulting to `removeIndex: true` only
+  became unambiguous after reading the dist source; one upstream-doc
+  disagreement during review cost extra round-trips.


### PR DESCRIPTION
## Summary

- Adds a "Build Artifacts and Type Pitfalls" section to root `CLAUDE.md` capturing four lessons surfaced during Phase 0 of the stack modernization (#681), so the next agent or human session avoids the same loops.
- Pitfalls captured: `as const` vs external SDK mutable parameters, generated `.d.ts` pulling source back through tsconfig `exclude`, CI ordering when scripts depend on build artifacts, and preferring `node_modules/<lib>/dist/` source over thin OSS docs.

### Why now

These four issues each cost extra review/CI round-trips during #681. They are blog-specific (Velite + Next.js migration context), so they belong in this repo's `CLAUDE.md` rather than the user's global rules.

## Test plan

- [x] Markdown renders cleanly in editor preview
- [x] No code or config changed; existing CI workflows are unaffected
- [ ] CI green on this PR (lint + test workflows still pass with no source changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)