### PR TITLE
chore(deps): ignore typescript and @types/node major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,15 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # TypeScript major bumps: hold until Velite/TanStack/Biome confirm support.
+      - dependency-name: "typescript"
+        update-types:
+          - "version-update:semver-major"
+      # @types/node should track the Node version pinned in .node-version (22 LTS).
+      - dependency-name: "@types/node"
+        update-types:
+          - "version-update:semver-major"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary
- Add Dependabot ignore rules so it stops opening PRs for TypeScript major bumps (5.x → 6.x) and @types/node major bumps (22.x → 25.x).
- TS 6.x ecosystem support in Velite / TanStack Router / Biome 2 is still unverified, and the previous Velite migration (see `CLAUDE.md`) flagged real TypeScript-version pitfalls — defer until downstream tooling confirms support.
- @types/node tracks the Node runtime, which is pinned at 22 LTS via `.node-version` (22.21.1). Major bumps should follow a runtime upgrade, not lead it.

## Context
Closes #695 (typescript 5.8 → 6.0).
Closes #692 (@types/node 22 → 25).

Minor / patch updates for both packages continue as before.

## Test plan
- [x] `dependabot.yml` parses (single ignore block, two entries)
- [ ] Confirm Dependabot does not re-open #695 / #692 after merge