### PR TITLE
Tokenize font families, bump bold weight, and add @ alias

### DIFF
--- a/styles/global.css
+++ b/styles/global.css
@@ -2,6 +2,7 @@ body {
   -webkit-font-smoothing: antialiased;
   background-color: var(--color-background);
   color: var(--color-text);
+  font-family: var(--font-family-base);
   font-weight: var(--font-weight);
   font-size: var(--font-size);
   transition:
@@ -78,7 +79,7 @@ li {
   overflow-x: auto;
   font-size: var(--font-size-small);
   line-height: 1.6;
-  font-family: "Consolas", "Monaco", "Andale Mono", "Ubuntu Mono", monospace;
+  font-family: var(--font-family-mono);
 }
 
 /* Inline code styles */
@@ -87,7 +88,7 @@ li {
   padding: 0.2em 0.4em;
   border-radius: 4px;
   font-size: var(--font-size-small);
-  font-family: "Consolas", "Monaco", "Andale Mono", "Ubuntu Mono", monospace;
+  font-family: var(--font-family-mono);
 }
 
 /* Link card styles */

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -10,13 +10,19 @@
 
   --content-width: 900px;
 
+  --font-family-base:
+    "Noto Sans JP", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif;
+  --font-family-mono:
+    "Consolas", "Monaco", "Andale Mono", "Ubuntu Mono", monospace;
+
   --font-size-small: 0.875rem;
   --font-size: 1rem;
   --font-size-large: 1.125rem;
   --font-size-jumbo: 2rem;
 
   --font-weight: 400;
-  --font-weight-bold: 700;
+  --font-weight-bold: 900;
 
   --line-height: 1.8;
 }

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -124,6 +124,11 @@ export default defineConfig({
   server: {
     port: 3000,
   },
+  resolve: {
+    alias: {
+      "@": __dirname,
+    },
+  },
   // Bundle all CSS modules into a single asset. With code-split CSS,
   // SPA navigation between routes drops the previous route's stylesheet
   // (incl. shared layout/* chunks), leaving the navi/footer unstyled


### PR DESCRIPTION
## Summary

- Centralize the body and code font stacks in `--font-family-base` / `--font-family-mono` so future restyles touch one place instead of every consumer in `global.css`.
- Bump `--font-weight-bold` from 700 to 900 to match the heavier weight intended for headings.
- Mirror the `@` path alias in `vite.config.mts` so resolution does not rely solely on TanStack Start's implicit behavior; the alias is already used across `app/` and `components/` and declared in `tsconfig.paths`.

## Test plan

- [x] `pnpm lint:ci`
- [x] `pnpm test` (tsc)
- [ ] `pnpm build` succeeds and prerendered pages render with the new font stack
- [ ] Visual smoke check: headings render at the heavier 900 weight in both light and dark themes