### PR TITLE
feat: Cosense source-of-truth — Phase 1 sync engine

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,43 @@
+name: Sync from Cosense
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry-run only (writes .sync-plan.json, no commit)"
+        required: false
+        default: "false"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+      - run: corepack enable
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: ./.node-version
+          cache: "pnpm"
+      - run: pnpm install --frozen-lockfile
+      - name: Run sync
+        run: pnpm sync ${{ inputs.dry_run == 'true' && '--dry-run' || '' }}
+        env:
+          COSENSE_PROJECT: ${{ secrets.COSENSE_PROJECT }}
+          COSENSE_SID:     ${{ secrets.COSENSE_SID }}
+      - name: Commit & push (skipped on dry-run)
+        if: inputs.dry_run != 'true'
+        run: |
+          if [ -n "$(git status --porcelain content public)" ]; then
+            git config user.name  "blog-sync[bot]"
+            git config user.email "blog-sync@users.noreply.github.com"
+            git add content public
+            git commit -m "sync: pull from Cosense"
+            git push origin main
+          fi
+      - name: Upload dry-run plan
+        if: inputs.dry_run == 'true' && hashFiles('.sync-plan.json') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: sync-plan
+          path: .sync-plan.json

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -5,7 +5,8 @@ on:
       dry_run:
         description: "Dry-run only (writes .sync-plan.json, no commit)"
         required: false
-        default: "false"
+        type: boolean
+        default: false
 
 jobs:
   sync:
@@ -21,12 +22,12 @@ jobs:
           cache: "pnpm"
       - run: pnpm install --frozen-lockfile
       - name: Run sync
-        run: pnpm sync ${{ inputs.dry_run == 'true' && '--dry-run' || '' }}
+        run: pnpm sync ${{ inputs.dry_run && '--dry-run' || '' }}
         env:
           COSENSE_PROJECT: ${{ secrets.COSENSE_PROJECT }}
           COSENSE_SID:     ${{ secrets.COSENSE_SID }}
       - name: Commit & push (skipped on dry-run)
-        if: inputs.dry_run != 'true'
+        if: ! inputs.dry_run
         run: |
           if [ -n "$(git status --porcelain content public)" ]; then
             git config user.name  "blog-sync[bot]"
@@ -36,7 +37,7 @@ jobs:
             git push origin main
           fi
       - name: Upload dry-run plan
-        if: inputs.dry_run == 'true' && hashFiles('.sync-plan.json') != ''
+        if: inputs.dry_run && hashFiles('.sync-plan.json') != ''
         uses: actions/upload-artifact@v4
         with:
           name: sync-plan

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Build content layer + tanstack start prerender
         run: pnpm build
       - run: pnpm test
+      - run: pnpm test:unit
       # Phase 2 smoke: prerender must emit home + profile + every velite
       # post (>= 111). Spot-check OGP meta on a known post — both an
       # original-slug post (php-replace-lf) and a renamed-slug post

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,9 @@ public/images/posts
 # Git worktrees (used by superpowers subagent workflow)
 .worktrees/
 
+# Superpowers brainstorm session artifacts
+.superpowers/
+
 # Local Claude Code permission settings (per-machine, not project state)
 .claude/
 

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/docs/superpowers/plans/2026-05-04-cosense-sync-phase-1.md
+++ b/docs/superpowers/plans/2026-05-04-cosense-sync-phase-1.md
@@ -665,6 +665,14 @@ describe("CosenseClient", () => {
     const c = new CosenseClient({ project: "demo", sid: "s", fetch: fetchMock })
     await expect(c.listPages()).rejects.toThrow(/503/)
   })
+
+  test("listPages aborts when count > pages.length (pagination needed)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ count: 1500, pages: listJson.pages }), { status: 200 }),
+    )
+    const c = new CosenseClient({ project: "demo", sid: "s", fetch: fetchMock })
+    await expect(c.listPages()).rejects.toThrow(/pagination is not yet implemented/)
+  })
 })
 ```
 
@@ -707,7 +715,13 @@ export class CosenseClient {
     const url = `${BASE}/${encodeURIComponent(this.project)}?limit=1000&skip=0`
     const r = await this.fetcher(url, { headers: this.headers() })
     if (!r.ok) throw new Error(`Cosense list failed: ${r.status}`)
-    return cosenseListResponseSchema.parse(await r.json())
+    const parsed = cosenseListResponseSchema.parse(await r.json())
+    if (parsed.count > parsed.pages.length) {
+      throw new Error(
+        `Cosense project has ${parsed.count} pages but client only fetched ${parsed.pages.length}; pagination is not yet implemented`,
+      )
+    }
+    return parsed
   }
 
   async getPage(title: string): Promise<CosensePage> {
@@ -719,7 +733,7 @@ export class CosenseClient {
 }
 ```
 
-Run: `pnpm test:unit lib/sync/cosense-client.test.ts` → green.
+Run: `pnpm test:unit lib/sync/cosense-client.test.ts` → green (6/6 tests).
 
 - [ ] **Step 4: Commit**
 
@@ -1693,6 +1707,7 @@ Verify in the GitHub Actions UI that "Sync from Cosense" appears under workflows
 
 ### Deliberate deviations from the spec
 
+- **Pagination is asserted, not implemented.** Phase 1 aborts loudly if a project exceeds 1000 pages; Phase 2 must add `skip`-loop pagination before the cron is enabled.
 - **Per-page error tolerance is deferred.** The spec describes a `.sync-errors.json` file and a "skip page, continue" policy for parse / image / schema failures. Phase 1's orchestrator throws on the first per-page failure, which aborts the whole run. This is acceptable while the workflow is `workflow_dispatch` only (operator sees the failure immediately and re-runs). Phase 2 must add the per-page tolerance before the cron is enabled, otherwise a single broken page will block all subsequent syncs.
 - **Pre-write `postSchema` validation is not implemented.** Phase 1 relies on the existing `pnpm build` (run by Cloudflare Pages or in CI) to catch schema drift. This is fine because Phase 1 doesn't run sync against `main` automatically.
 - **Cron schedule is not enabled.** `sync.yml` ships with `workflow_dispatch:` only. Phase 2 adds `schedule:` after migration data lands.

--- a/docs/superpowers/plans/2026-05-04-cosense-sync-phase-1.md
+++ b/docs/superpowers/plans/2026-05-04-cosense-sync-phase-1.md
@@ -145,9 +145,12 @@ The IR is the only stable contract between sync stages. Keep it intentionally na
 // lib/sync/types.ts
 import { z } from "zod"
 
+/** Cosense page id format: 24 lowercase hex characters. */
+export const PAGE_ID_RE = /^[a-f0-9]{24}$/
+
 /** Cosense page object as returned by /api/pages/<project>/<title>. */
 export const cosensePageSchema = z.object({
-  id: z.string().regex(/^[a-f0-9]{24}$/),
+  id: z.string().regex(PAGE_ID_RE),
   title: z.string().min(1),
   created: z.number().int().nonnegative(),
   updated: z.number().int().nonnegative(),
@@ -165,7 +168,7 @@ export type CosensePage = z.infer<typeof cosensePageSchema>
 
 /** Cosense list entry as returned by /api/pages/<project>. */
 export const cosenseListEntrySchema = z.object({
-  id: z.string().regex(/^[a-f0-9]{24}$/),
+  id: z.string().regex(PAGE_ID_RE),
   title: z.string().min(1),
   updated: z.number().int().nonnegative(),
 })
@@ -515,13 +518,17 @@ test("rejects non-id input", () => {
   expect(isValidSlug("Not An Id")).toBe(false)
   expect(isValidSlug("0123456789abcdef01234567")).toBe(true)
 })
+
+test("slugForPageId throws with descriptive message on invalid input", () => {
+  expect(() => slugForPageId("not-a-page-id")).toThrow(/invalid Cosense page id/)
+})
 ```
 
 - [ ] **Step 2: Implement and verify**
 
 ```ts
 // lib/sync/slug.ts
-const PAGE_ID_RE = /^[a-f0-9]{24}$/
+import { PAGE_ID_RE } from "./types"
 
 export function slugForPageId(pageId: string): string {
   if (!PAGE_ID_RE.test(pageId)) {

--- a/docs/superpowers/plans/2026-05-04-cosense-sync-phase-1.md
+++ b/docs/superpowers/plans/2026-05-04-cosense-sync-phase-1.md
@@ -918,7 +918,7 @@ git commit -m "Add Cosense page -> IR transform"
 - Create: `lib/sync/images.test.ts`
 - Create: `lib/sync/images.ts`
 
-Idempotent: if the file already exists with matching size, do not refetch. Errors are surfaced (caller decides to skip the page).
+Idempotent: if the file already exists, do not refetch (writes are atomic via tmp + rename). Errors are surfaced (caller decides to skip the page).
 
 - [ ] **Step 1: Write the failing test**
 
@@ -975,6 +975,21 @@ test("propagates fetch failure", async () => {
     ),
   ).rejects.toThrow(/404/)
 })
+
+test("does not leave a .tmp file when fetch succeeds", async () => {
+  const fetchMock = vi.fn().mockResolvedValue(
+    new Response(new Uint8Array([5]), { status: 200 }),
+  )
+  await downloadImages(
+    [{ url: "https://gyazo.com/c.png", filename: "c.png" }],
+    dir,
+    { fetch: fetchMock },
+  )
+  expect(Buffer.from(readFileSync(join(dir, "c.png")))).toEqual(
+    Buffer.from([5]),
+  )
+  expect(() => statSync(join(dir, "c.png.tmp"))).toThrow()
+})
 ```
 
 Run: `pnpm test:unit lib/sync/images.test.ts` → red.
@@ -984,7 +999,7 @@ Run: `pnpm test:unit lib/sync/images.test.ts` → red.
 ```ts
 // lib/sync/images.ts
 import { existsSync } from "node:fs"
-import { writeFile } from "node:fs/promises"
+import { rename, unlink, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import type { ImageRef } from "./types"
 
@@ -1004,7 +1019,14 @@ export async function downloadImages(
     const r = await fetcher(ref.url)
     if (!r.ok) throw new Error(`image fetch ${ref.url} -> ${r.status}`)
     const buf = new Uint8Array(await r.arrayBuffer())
-    await writeFile(dest, buf)
+    const tmp = `${dest}.tmp`
+    await writeFile(tmp, buf)
+    try {
+      await rename(tmp, dest)
+    } catch (err) {
+      await unlink(tmp).catch(() => {})
+      throw err
+    }
   }
 }
 ```

--- a/docs/superpowers/plans/2026-05-04-cosense-sync-phase-1.md
+++ b/docs/superpowers/plans/2026-05-04-cosense-sync-phase-1.md
@@ -1539,15 +1539,33 @@ async function readLocalStateAt(postsRoot: string): Promise<LocalPostState[]> {
 if (import.meta.url === `file://${process.argv[1]}`) {
   const args = parseArgs(process.argv.slice(2))
   const env = envSchema.parse(process.env)
-  const seed = await readSeed()
-  await runSync({
-    client: new CosenseClient({ project: env.COSENSE_PROJECT, sid: env.COSENSE_SID }),
-    postsRoot: POSTS_ROOT,
-    redirectsPath: REDIRECTS_PATH,
-    seed,
-    maxDeleteRatio: env.MAX_DELETE_RATIO,
-    dryRun: args.dryRun,
-  }).catch((err) => { console.error(err); process.exit(1) })
+  readSeed()
+    .then((seed) =>
+      runSync({
+        client: new CosenseClient({
+          project: env.COSENSE_PROJECT,
+          sid: env.COSENSE_SID,
+        }),
+        postsRoot: POSTS_ROOT,
+        redirectsPath: REDIRECTS_PATH,
+        seed,
+        maxDeleteRatio: env.MAX_DELETE_RATIO,
+        dryRun: args.dryRun,
+      }),
+    )
+    .then(async ({ plan }) => {
+      console.log(`plan: ${plan.actions.map((a) => a.kind).join(",")}`)
+      if (args.dryRun) {
+        await writeFile(
+          resolve(process.cwd(), ".sync-plan.json"),
+          JSON.stringify(plan, null, 2),
+        )
+      }
+    })
+    .catch((err) => {
+      console.error(err)
+      process.exit(1)
+    })
 }
 ```
 
@@ -1557,7 +1575,7 @@ Add `mkdir` to the existing `node:fs/promises` import. Remove the previous `main
 
 ```ts
 // scripts/sync-cosense.test.ts
-import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs"
+import { mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs"
 import { mkdir } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
@@ -1575,9 +1593,18 @@ let root: string
 beforeEach(() => { root = mkdtempSync(join(tmpdir(), "sync-int-")) })
 afterEach(() => { rmSync(root, { recursive: true, force: true }) })
 
-const stubClient = (detail = detailJson) => ({
+const stubClient = () => ({
   listPages: vi.fn().mockResolvedValue(listJson),
-  getPage: vi.fn().mockResolvedValue(detail),
+  getPage: vi.fn().mockImplementation((title: string) => {
+    const page = listJson.pages.find((p: { title: string }) => p.title === title)
+    // Return a full page detail whose id matches the list entry so each post
+    // lands in its own directory on disk. Fall back to the fixture for unknown titles.
+    return Promise.resolve(
+      page
+        ? { ...detailJson, id: page.id, title: page.title }
+        : detailJson,
+    )
+  }),
 })
 
 test("dry-run produces a plan without touching disk", async () => {
@@ -1596,13 +1623,14 @@ test("dry-run produces a plan without touching disk", async () => {
 })
 
 test("real run creates post directories and is idempotent", async () => {
-  const c = stubClient()
+  const c1 = stubClient()
   const fetchStub = vi.fn().mockResolvedValue(
     new Response(new Uint8Array([1]), { status: 200 }),
   )
   await mkdir(join(root, "posts"), { recursive: true })
+
   await runSync({
-    client: c,
+    client: c1,
     postsRoot: join(root, "posts"),
     redirectsPath: join(root, "_redirects"),
     seed: [],
@@ -1611,12 +1639,16 @@ test("real run creates post directories and is idempotent", async () => {
     fetch: fetchStub,
   })
   const id = listJson.pages[0].id
-  expect(readFileSync(join(root, "posts", id, "index.md"), "utf8")).toContain(`path: /${id}`)
+  const dest = join(root, "posts", id, "index.md")
+  expect(readFileSync(dest, "utf8")).toContain(`path: /${id}`)
+  const mtime1 = statSync(dest).mtimeMs
+  const getPageCallsAfterFirst = c1.getPage.mock.calls.length
 
-  // second run is a no-op
-  c.getPage.mockClear()
+  // Second run with a fresh stub (mtime check below is the actual idempotency proof).
+  await new Promise((r) => setTimeout(r, 20))
+  const c2 = stubClient()
   await runSync({
-    client: stubClient(),
+    client: c2,
     postsRoot: join(root, "posts"),
     redirectsPath: join(root, "_redirects"),
     seed: [],
@@ -1624,7 +1656,12 @@ test("real run creates post directories and is idempotent", async () => {
     dryRun: false,
     fetch: fetchStub,
   })
-  // both pages now appear unchanged based on frontmatter updated_at
+  // No second-run getPage calls because both pages are now "unchanged".
+  expect(c2.getPage).not.toHaveBeenCalled()
+  // Initial run did call getPage twice (once per fixture page).
+  expect(getPageCallsAfterFirst).toBe(listJson.pages.length)
+  // mtime unchanged — fs-writer.writePost short-circuited the no-op.
+  expect(statSync(dest).mtimeMs).toBe(mtime1)
 })
 
 test("aborts when deletes exceed ratio", async () => {
@@ -1784,6 +1821,7 @@ Verify in the GitHub Actions UI that "Sync from Cosense" appears under workflows
 - The integration test in Task 13 stubs the client object directly rather than spawning a subprocess. Do not be tempted to spawn `tsx scripts/sync-cosense.ts` — it adds 2-3 s per test for no signal gain.
 - If the Scrapbox notation table grows past ~15 rows, split the table tests into thematic `describe` blocks but keep the data-driven structure.
 - `lib/sync/redirects-seed.json` is intentionally absent from this plan. Phase 2 creates it.
+- **Phase 1 uses a regex instead of `gray-matter` to parse `updated_at` from existing frontmatter.** `gray-matter@4` calls `js-yaml.safeLoad` internally, which was removed in `js-yaml@4`. This repo overrides `js-yaml` to `>=4.x`, so importing `gray-matter` for frontmatter parsing would throw at runtime. The `UPDATED_AT_RE` regex in `scripts/sync-cosense.ts` is an intentional workaround — do not replace it with `gray-matter` unless `js-yaml` is pinned to `^3.x` first.
 
 ### Deliberate deviations from the spec
 

--- a/docs/superpowers/plans/2026-05-04-cosense-sync-phase-1.md
+++ b/docs/superpowers/plans/2026-05-04-cosense-sync-phase-1.md
@@ -1,0 +1,1670 @@
+# Cosense sync — Phase 1 (sync infrastructure) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the one-way Cosense → repo sync engine end-to-end, runnable manually via `pnpm sync` and via `gh workflow run sync.yml`. No cron, no migration, no production data — Phase 2 takes care of those.
+
+**Architecture:** A thin orchestrator (`scripts/sync-cosense.ts`) drives a fan of pure / single-responsibility modules under `lib/sync/`. The IR (intermediate representation) defined in `lib/sync/types.ts` is the only stable contract: Cosense client returns IR, markdown emitter consumes IR. Everything that can be a pure function is one — fixtures and unit tests live next to the source.
+
+**Tech Stack:** TypeScript 5.9, vitest (new), zod (new), tsx (existing), pnpm 9, GitHub Actions, Cosense REST API.
+
+**Spec:** `docs/superpowers/specs/2026-05-04-cosense-source-of-truth-design.md` (Phase 1 only).
+
+**Branch:** `docs/cosense-source-of-truth-spec` is already checked out and carries the spec commit. Create the implementation branch from `origin/main` per CLAUDE.md (`git fetch -p origin && git switch -c feat/cosense-sync-phase-1 origin/main`); cherry-pick `701e2c4` so the spec rides along, or merge from the docs branch when both are PR-ready.
+
+---
+
+## File Structure
+
+**Created:**
+
+- `vitest.config.ts` — minimal vitest config rooted at the repo, picks up `lib/**/*.test.ts`.
+- `lib/sync/types.ts` — IR types + small zod schemas for API boundaries.
+- `lib/sync/scrapbox-to-md.ts` — pure `(string) => string` notation translator.
+- `lib/sync/scrapbox-to-md.test.ts` — table tests, one row per supported notation.
+- `lib/sync/cosense-client.ts` — REST wrapper, returns parsed IR-friendly shapes.
+- `lib/sync/cosense-client.test.ts` — contract tests against captured fixtures.
+- `lib/sync/__fixtures__/pages-list.json` — captured `/api/pages/<project>` response.
+- `lib/sync/__fixtures__/page-detail.json` — captured `/api/pages/<project>/<title>` response.
+- `lib/sync/transform.ts` — Cosense page object → IR `Post`.
+- `lib/sync/transform.test.ts` — covers metadata extraction (tags, description).
+- `lib/sync/frontmatter.ts` — IR → YAML frontmatter string.
+- `lib/sync/frontmatter.test.ts` — round-trip + key ordering.
+- `lib/sync/slug.ts` — page id → slug helpers.
+- `lib/sync/slug.test.ts` — collision and shape checks.
+- `lib/sync/images.ts` — download Gyazo / scrapbox.io images to a target directory.
+- `lib/sync/images.test.ts` — uses a stubbed `fetch` to verify path layout, idempotency.
+- `lib/sync/fs-writer.ts` — idempotent writer for `content/posts/<id>/`.
+- `lib/sync/fs-writer.test.ts` — second run is byte-identical and a no-op.
+- `lib/sync/redirects.ts` — `(seed[]) => string` emitter; empty seed → empty output.
+- `lib/sync/redirects.test.ts` — empty seed, single entry, collision detection.
+- `lib/sync/diff.ts` — given remote pages + local dirs, classify new / updated / deleted.
+- `lib/sync/diff.test.ts` — exhaustive small cases.
+- `scripts/sync-cosense.ts` — orchestrator CLI (no transform logic).
+- `scripts/sync-cosense.test.ts` — integration test using stubbed client + tmp dir.
+- `.github/workflows/sync.yml` — `workflow_dispatch` only in Phase 1; cron added in Phase 2.
+
+**Modified:**
+
+- `package.json` — add `vitest`, `zod` deps; add `sync`, `test:unit` scripts.
+- `pnpm-lock.yaml` — generated.
+- `.github/workflows/test.yml` — add a `pnpm test:unit` step after the existing `pnpm test`.
+- `tsconfig.json` — add `vitest.config.ts` to `include`.
+
+**Untouched:** `app/`, `components/`, `styles/`, `velite.config.ts`, `vite.config.mts`, every existing file under `lib/` outside `lib/sync/`.
+
+---
+
+## Task 1: Test infrastructure (vitest + zod)
+
+**Files:**
+- Modify: `package.json`
+- Create: `vitest.config.ts`
+- Modify: `tsconfig.json`
+- Create: `lib/sync/__smoke__.test.ts` (deleted at end of task)
+
+- [ ] **Step 1: Add dev deps and scripts**
+
+```bash
+pnpm add -D vitest@^2.1.0
+pnpm add zod@^3.23.8
+```
+
+Then edit `package.json` `scripts` block — add two entries, leave `test` (= tsc) alone:
+
+```json
+    "sync": "tsx scripts/sync-cosense.ts",
+    "test:unit": "vitest run",
+    "test:unit:watch": "vitest",
+```
+
+- [ ] **Step 2: Create `vitest.config.ts`**
+
+```ts
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    include: ["lib/**/*.test.ts", "scripts/**/*.test.ts"],
+    environment: "node",
+    reporters: "default",
+    pool: "forks",
+  },
+  resolve: {
+    alias: { "@": new URL(".", import.meta.url).pathname.replace(/\/$/, "") },
+  },
+})
+```
+
+- [ ] **Step 3: Add `vitest.config.ts` to tsconfig include**
+
+Edit `tsconfig.json` `include`, add `"vitest.config.ts"` between `"styles/**/*.tsx"` and `"vite.config.mts"`. Do not touch `exclude`.
+
+- [ ] **Step 4: Write a smoke test**
+
+Create `lib/sync/__smoke__.test.ts`:
+
+```ts
+import { expect, test } from "vitest"
+
+test("vitest can run a trivial assertion", () => {
+  expect(1 + 1).toBe(2)
+})
+```
+
+- [ ] **Step 5: Verify the smoke test passes**
+
+Run: `pnpm test:unit`
+Expected output ends with `Test Files  1 passed (1)` / `Tests  1 passed (1)`.
+
+Also run: `pnpm test` — must still pass (existing tsc gate).
+
+- [ ] **Step 6: Delete the smoke file and commit**
+
+```bash
+rm lib/sync/__smoke__.test.ts
+git add package.json pnpm-lock.yaml vitest.config.ts tsconfig.json
+git commit -m "Add vitest + zod for the Cosense sync engine"
+```
+
+---
+
+## Task 2: IR types (`lib/sync/types.ts`)
+
+**Files:**
+- Create: `lib/sync/types.ts`
+
+The IR is the only stable contract between sync stages. Keep it intentionally narrow — fields the markdown emitter and frontmatter emitter actually consume.
+
+- [ ] **Step 1: Write the file**
+
+```ts
+// lib/sync/types.ts
+import { z } from "zod"
+
+/** Cosense page object as returned by /api/pages/<project>/<title>. */
+export const cosensePageSchema = z.object({
+  id: z.string().regex(/^[a-f0-9]{24}$/),
+  title: z.string().min(1),
+  created: z.number().int().nonnegative(),
+  updated: z.number().int().nonnegative(),
+  lines: z.array(
+    z.object({
+      id: z.string(),
+      text: z.string(),
+      userId: z.string(),
+      created: z.number().int(),
+      updated: z.number().int(),
+    }),
+  ),
+})
+export type CosensePage = z.infer<typeof cosensePageSchema>
+
+/** Cosense list entry as returned by /api/pages/<project>. */
+export const cosenseListEntrySchema = z.object({
+  id: z.string().regex(/^[a-f0-9]{24}$/),
+  title: z.string().min(1),
+  updated: z.number().int().nonnegative(),
+})
+export type CosenseListEntry = z.infer<typeof cosenseListEntrySchema>
+
+export const cosenseListResponseSchema = z.object({
+  count: z.number().int().nonnegative(),
+  pages: z.array(cosenseListEntrySchema),
+})
+
+/** Internal Representation of a single blog post. */
+export interface Post {
+  id: string                 // Cosense page id, also the directory name + URL slug
+  title: string
+  createdAt: Date
+  updatedAt: Date
+  description: string        // first non-empty body line, trimmed
+  tags: string[]
+  body: string               // markdown body without frontmatter
+  images: ImageRef[]         // images referenced by body, downloaded by sync
+}
+
+export interface ImageRef {
+  /** URL on Cosense / Gyazo / scrapbox.io. */
+  url: string
+  /** Filename used inside the post directory (also referenced by body). */
+  filename: string
+}
+
+/** Output of diff stage. */
+export type SyncAction =
+  | { kind: "create"; page: CosenseListEntry }
+  | { kind: "update"; page: CosenseListEntry }
+  | { kind: "delete"; id: string }
+  | { kind: "unchanged"; id: string }
+
+export interface SyncPlan {
+  actions: SyncAction[]
+  /** Number of currently existing local post directories before sync. */
+  localCount: number
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `pnpm test`
+Expected: PASS (tsc).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/sync/types.ts
+git commit -m "Add IR types for Cosense sync"
+```
+
+---
+
+## Task 3: Scrapbox → markdown (TDD core)
+
+**Files:**
+- Create: `lib/sync/scrapbox-to-md.test.ts`
+- Create: `lib/sync/scrapbox-to-md.ts`
+
+This is the highest-bug-surface module in the project. We TDD it notation by notation. Keep the function pure and string-in-string-out.
+
+- [ ] **Step 1: Write the failing notation table**
+
+Create `lib/sync/scrapbox-to-md.test.ts`:
+
+```ts
+import { describe, expect, test } from "vitest"
+import { scrapboxToMarkdown } from "./scrapbox-to-md"
+
+describe("scrapboxToMarkdown", () => {
+  const cases: Array<[label: string, input: string, expected: string]> = [
+    ["plain line",     "hello world",                    "hello world"],
+    ["bold via [* ]",  "[* very important]",              "**very important**"],
+    ["heading h3 [** ]", "[** medium]",                   "### medium"],
+    ["heading h2 [*** ]", "[*** big]",                    "## big"],
+    ["heading h1 [**** ]", "[**** huge]",                 "# huge"],
+    ["inline code",    "use `pnpm sync` daily",           "use `pnpm sync` daily"],
+    ["external url",   "[https://example.com Example]",   "[Example](https://example.com)"],
+    ["bare url",       "[https://example.com]",           "<https://example.com>"],
+    ["hashtag stays inline", "see #blog for more",        "see #blog for more"],
+    ["gyazo image",    "[https://gyazo.com/abc123]",      "![](abc123.png)"],
+    ["scrapbox image", "[https://scrapbox.io/files/xyz.png]", "![](xyz.png)"],
+    ["internal link",  "[Other Page]",                    "**Other Page**"],
+    ["blockquote",     "> quoted",                         "> quoted"],
+  ]
+  for (const [label, input, expected] of cases) {
+    test(label, () => {
+      expect(scrapboxToMarkdown(input)).toBe(expected)
+    })
+  }
+
+  test("multi-line body keeps order and blank lines", () => {
+    const input = "[**** Title]\n\nIntro paragraph\n\n[* note]"
+    expect(scrapboxToMarkdown(input)).toBe(
+      "# Title\n\nIntro paragraph\n\n**note**",
+    )
+  })
+
+  test("fenced code block: 'code:filename.ts' followed by indented lines", () => {
+    const input = "code:hello.ts\n const x = 1\n const y = 2"
+    expect(scrapboxToMarkdown(input)).toBe(
+      "```ts\nconst x = 1\nconst y = 2\n```",
+    )
+  })
+})
+```
+
+- [ ] **Step 2: Run the test, confirm red**
+
+Run: `pnpm test:unit lib/sync/scrapbox-to-md.test.ts`
+Expected: FAIL with `Cannot find module './scrapbox-to-md'`.
+
+- [ ] **Step 3: Implement the translator**
+
+Create `lib/sync/scrapbox-to-md.ts`:
+
+```ts
+// lib/sync/scrapbox-to-md.ts
+//
+// Pure (string) => string translator. Handles only the notation that
+// the test table covers. New notation discovered in real Cosense
+// content adds a row to the table FIRST, then is implemented here.
+
+const HEADING_LEVELS: Record<number, string> = { 4: "#", 3: "##", 2: "###" }
+
+const GYAZO_RE = /^\[https:\/\/gyazo\.com\/([a-zA-Z0-9]+)(?:\.[a-z]+)?\]$/
+const SCRAPBOX_FILE_RE =
+  /^\[https:\/\/scrapbox\.io\/files\/([a-zA-Z0-9]+\.[a-z]+)\]$/
+const URL_TITLE_RE = /^\[(https?:\/\/\S+)\s+(.+)\]$/
+const URL_BARE_RE = /^\[(https?:\/\/\S+)\]$/
+const STAR_RE = /^\[(\*+)\s+(.+)\]$/
+const INTERNAL_RE = /^\[([^\]]+)\]$/
+const CODE_OPEN_RE = /^code:([^\s]+)$/
+
+function transformInline(line: string): string {
+  // Whole-line wrappers handled first.
+  let m: RegExpMatchArray | null
+  if ((m = line.match(GYAZO_RE))) return `![](${m[1]}.png)`
+  if ((m = line.match(SCRAPBOX_FILE_RE))) return `![](${m[1]})`
+  if ((m = line.match(URL_TITLE_RE))) return `[${m[2]}](${m[1]})`
+  if ((m = line.match(URL_BARE_RE))) return `<${m[1]}>`
+  if ((m = line.match(STAR_RE))) {
+    const stars = m[1].length
+    const text = m[2]
+    return stars === 1 ? `**${text}**` : `${HEADING_LEVELS[stars] ?? "###"} ${text}`
+  }
+  if ((m = line.match(INTERNAL_RE)) && !m[1].startsWith("http")) {
+    return `**${m[1]}**`
+  }
+  return line
+}
+
+export function scrapboxToMarkdown(input: string): string {
+  const lines = input.split("\n")
+  const out: string[] = []
+  let i = 0
+  while (i < lines.length) {
+    const raw = lines[i]
+    const codeOpen = raw.match(CODE_OPEN_RE)
+    if (codeOpen) {
+      const filename = codeOpen[1]
+      const ext = filename.includes(".") ? filename.split(".").pop()! : ""
+      const code: string[] = []
+      i++
+      while (i < lines.length && lines[i].startsWith(" ")) {
+        code.push(lines[i].slice(1))
+        i++
+      }
+      out.push("```" + ext)
+      out.push(...code)
+      out.push("```")
+      continue
+    }
+    out.push(transformInline(raw))
+    i++
+  }
+  return out.join("\n")
+}
+```
+
+- [ ] **Step 4: Run the test, confirm green**
+
+Run: `pnpm test:unit lib/sync/scrapbox-to-md.test.ts`
+Expected: all rows pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/sync/scrapbox-to-md.ts lib/sync/scrapbox-to-md.test.ts
+git commit -m "Add Scrapbox notation -> markdown translator with table tests"
+```
+
+---
+
+## Task 4: Frontmatter emitter (`lib/sync/frontmatter.ts`)
+
+**Files:**
+- Create: `lib/sync/frontmatter.test.ts`
+- Create: `lib/sync/frontmatter.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// lib/sync/frontmatter.test.ts
+import { expect, test } from "vitest"
+import { emitFrontmatter } from "./frontmatter"
+import type { Post } from "./types"
+
+const post: Post = {
+  id: "0123456789abcdef01234567",
+  title: "Sample Post",
+  createdAt: new Date("2026-05-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-05-04T12:34:56.000Z"),
+  description: "First line of the body, trimmed.",
+  tags: ["sample", "demo"],
+  body: "ignored by frontmatter emitter",
+  images: [],
+}
+
+test("emits keys in a stable order", () => {
+  expect(emitFrontmatter(post)).toBe(
+    [
+      "---",
+      "title: Sample Post",
+      "created_at: '2026-05-01T00:00:00.000Z'",
+      "updated_at: '2026-05-04T12:34:56.000Z'",
+      "path: /0123456789abcdef01234567",
+      "description: 'First line of the body, trimmed.'",
+      "tags:",
+      "  - sample",
+      "  - demo",
+      "---",
+      "",
+    ].join("\n"),
+  )
+})
+
+test("omits tags entirely when empty", () => {
+  const out = emitFrontmatter({ ...post, tags: [] })
+  expect(out).not.toContain("tags:")
+})
+
+test("escapes single quotes in title", () => {
+  const out = emitFrontmatter({ ...post, title: "Don't break" })
+  expect(out).toContain("title: \"Don't break\"")
+})
+```
+
+- [ ] **Step 2: Run, confirm red**
+
+Run: `pnpm test:unit lib/sync/frontmatter.test.ts`
+Expected: FAIL with module-not-found.
+
+- [ ] **Step 3: Implement the emitter**
+
+```ts
+// lib/sync/frontmatter.ts
+import type { Post } from "./types"
+
+function quoteIfNeeded(s: string): string {
+  // YAML: single-quote strings unless they themselves contain single quotes.
+  if (s.includes("'")) return `"${s.replace(/"/g, '\\"')}"`
+  return `'${s}'`
+}
+
+function plainOrQuoted(s: string): string {
+  // Strings that look "safe" (no special chars, no leading whitespace) can
+  // go unquoted. Frontmatter consumers (gray-matter via Velite) accept both.
+  if (/^[A-Za-z0-9 _.-]+$/.test(s) && s.trim() === s) return s
+  return quoteIfNeeded(s)
+}
+
+export function emitFrontmatter(post: Post): string {
+  const lines: string[] = ["---"]
+  lines.push(`title: ${plainOrQuoted(post.title)}`)
+  lines.push(`created_at: '${post.createdAt.toISOString()}'`)
+  lines.push(`updated_at: '${post.updatedAt.toISOString()}'`)
+  lines.push(`path: /${post.id}`)
+  lines.push(`description: ${quoteIfNeeded(post.description)}`)
+  if (post.tags.length > 0) {
+    lines.push("tags:")
+    for (const tag of post.tags) lines.push(`  - ${tag}`)
+  }
+  lines.push("---", "")
+  return lines.join("\n")
+}
+```
+
+- [ ] **Step 4: Run, confirm green**
+
+Run: `pnpm test:unit lib/sync/frontmatter.test.ts`
+Expected: all 3 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/sync/frontmatter.ts lib/sync/frontmatter.test.ts
+git commit -m "Add YAML frontmatter emitter for sync output"
+```
+
+---
+
+## Task 5: Slug helper (`lib/sync/slug.ts`)
+
+**Files:**
+- Create: `lib/sync/slug.test.ts`
+- Create: `lib/sync/slug.ts`
+
+Trivial today (page id IS the slug) but isolated so future schemes can swap in here.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// lib/sync/slug.test.ts
+import { expect, test } from "vitest"
+import { isValidSlug, slugForPageId } from "./slug"
+
+test("page id passes through verbatim", () => {
+  expect(slugForPageId("0123456789abcdef01234567")).toBe(
+    "0123456789abcdef01234567",
+  )
+})
+
+test("rejects non-id input", () => {
+  expect(isValidSlug("Not An Id")).toBe(false)
+  expect(isValidSlug("0123456789abcdef01234567")).toBe(true)
+})
+```
+
+- [ ] **Step 2: Implement and verify**
+
+```ts
+// lib/sync/slug.ts
+const PAGE_ID_RE = /^[a-f0-9]{24}$/
+
+export function slugForPageId(pageId: string): string {
+  if (!PAGE_ID_RE.test(pageId)) {
+    throw new Error(`invalid Cosense page id: ${pageId}`)
+  }
+  return pageId
+}
+
+export function isValidSlug(s: string): boolean {
+  return PAGE_ID_RE.test(s)
+}
+```
+
+Run: `pnpm test:unit lib/sync/slug.test.ts` → green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/sync/slug.ts lib/sync/slug.test.ts
+git commit -m "Add slug helper (page id passthrough, validated)"
+```
+
+---
+
+## Task 6: Cosense client + fixtures (contract test)
+
+**Files:**
+- Create: `lib/sync/__fixtures__/pages-list.json` (hand-shaped or captured)
+- Create: `lib/sync/__fixtures__/page-detail.json`
+- Create: `lib/sync/cosense-client.test.ts`
+- Create: `lib/sync/cosense-client.ts`
+
+The client never depends on a live Cosense in tests. Fixtures are real responses captured once and committed.
+
+- [ ] **Step 1: Create fixtures**
+
+`lib/sync/__fixtures__/pages-list.json`:
+
+```json
+{
+  "count": 2,
+  "pages": [
+    {
+      "id": "0123456789abcdef01234567",
+      "title": "First Post",
+      "created": 1714521600,
+      "updated": 1714694400
+    },
+    {
+      "id": "fedcba9876543210fedcba98",
+      "title": "Second Post",
+      "created": 1714521600,
+      "updated": 1714694400
+    }
+  ]
+}
+```
+
+`lib/sync/__fixtures__/page-detail.json`:
+
+```json
+{
+  "id": "0123456789abcdef01234567",
+  "title": "First Post",
+  "created": 1714521600,
+  "updated": 1714694400,
+  "lines": [
+    { "id": "l1", "text": "First Post",  "userId": "u1", "created": 1714521600, "updated": 1714521600 },
+    { "id": "l2", "text": "Intro line.", "userId": "u1", "created": 1714521600, "updated": 1714521600 },
+    { "id": "l3", "text": "[* highlight]","userId": "u1", "created": 1714521600, "updated": 1714521600 }
+  ]
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```ts
+// lib/sync/cosense-client.test.ts
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { describe, expect, test, vi } from "vitest"
+import {
+  cosenseListResponseSchema,
+  cosensePageSchema,
+} from "./types"
+import { CosenseClient } from "./cosense-client"
+
+const listJson = JSON.parse(
+  readFileSync(resolve(__dirname, "__fixtures__/pages-list.json"), "utf8"),
+)
+const detailJson = JSON.parse(
+  readFileSync(resolve(__dirname, "__fixtures__/page-detail.json"), "utf8"),
+)
+
+describe("schemas accept captured fixtures", () => {
+  test("list response", () => {
+    expect(() => cosenseListResponseSchema.parse(listJson)).not.toThrow()
+  })
+  test("page detail", () => {
+    expect(() => cosensePageSchema.parse(detailJson)).not.toThrow()
+  })
+})
+
+describe("CosenseClient", () => {
+  test("listPages hits /api/pages/<project> and parses response", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(listJson), { status: 200 }),
+    )
+    const c = new CosenseClient({ project: "demo", sid: "s", fetch: fetchMock })
+    const result = await c.listPages()
+    expect(result.pages).toHaveLength(2)
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://scrapbox.io/api/pages/demo?limit=1000&skip=0",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Cookie: "connect.sid=s" }),
+      }),
+    )
+  })
+
+  test("getPage URL-encodes the title", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(detailJson), { status: 200 }),
+    )
+    const c = new CosenseClient({ project: "demo", sid: "s", fetch: fetchMock })
+    await c.getPage("Hello World")
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://scrapbox.io/api/pages/demo/Hello%20World",
+      expect.any(Object),
+    )
+  })
+
+  test("non-2xx throws", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("x", { status: 503 }))
+    const c = new CosenseClient({ project: "demo", sid: "s", fetch: fetchMock })
+    await expect(c.listPages()).rejects.toThrow(/503/)
+  })
+})
+```
+
+Run: `pnpm test:unit lib/sync/cosense-client.test.ts` → red, module not found.
+
+- [ ] **Step 3: Implement the client**
+
+```ts
+// lib/sync/cosense-client.ts
+import {
+  type CosensePage,
+  cosenseListResponseSchema,
+  cosensePageSchema,
+} from "./types"
+
+export interface CosenseClientOptions {
+  project: string
+  sid: string
+  fetch?: typeof globalThis.fetch
+}
+
+const BASE = "https://scrapbox.io/api/pages"
+
+export class CosenseClient {
+  private readonly project: string
+  private readonly sid: string
+  private readonly fetcher: typeof globalThis.fetch
+
+  constructor(opts: CosenseClientOptions) {
+    this.project = opts.project
+    this.sid = opts.sid
+    this.fetcher = opts.fetch ?? globalThis.fetch
+  }
+
+  private headers(): HeadersInit {
+    return { Cookie: `connect.sid=${this.sid}` }
+  }
+
+  async listPages() {
+    const url = `${BASE}/${encodeURIComponent(this.project)}?limit=1000&skip=0`
+    const r = await this.fetcher(url, { headers: this.headers() })
+    if (!r.ok) throw new Error(`Cosense list failed: ${r.status}`)
+    return cosenseListResponseSchema.parse(await r.json())
+  }
+
+  async getPage(title: string): Promise<CosensePage> {
+    const url = `${BASE}/${encodeURIComponent(this.project)}/${encodeURIComponent(title)}`
+    const r = await this.fetcher(url, { headers: this.headers() })
+    if (!r.ok) throw new Error(`Cosense getPage failed: ${r.status}`)
+    return cosensePageSchema.parse(await r.json())
+  }
+}
+```
+
+Run: `pnpm test:unit lib/sync/cosense-client.test.ts` → green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/sync/cosense-client.ts lib/sync/cosense-client.test.ts \
+        lib/sync/__fixtures__/pages-list.json lib/sync/__fixtures__/page-detail.json
+git commit -m "Add Cosense REST client with fixture-driven contract tests"
+```
+
+---
+
+## Task 7: Page → IR transform (`lib/sync/transform.ts`)
+
+**Files:**
+- Create: `lib/sync/transform.test.ts`
+- Create: `lib/sync/transform.ts`
+
+This module: drops the title line (Cosense pages always start with the title as line 0), extracts hashtags and image refs from the body, derives `description`, and returns an IR `Post`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// lib/sync/transform.test.ts
+import { expect, test } from "vitest"
+import { transformPage } from "./transform"
+import type { CosensePage } from "./types"
+
+const page: CosensePage = {
+  id: "0123456789abcdef01234567",
+  title: "First Post",
+  created: 1714521600,
+  updated: 1714694400,
+  lines: [
+    { id: "l1", text: "First Post",                           userId: "u", created: 1, updated: 1 },
+    { id: "l2", text: "Intro paragraph.",                     userId: "u", created: 1, updated: 1 },
+    { id: "l3", text: "Body line with #blog #demo tags",      userId: "u", created: 1, updated: 1 },
+    { id: "l4", text: "[https://gyazo.com/ABCDEF123456.png]", userId: "u", created: 1, updated: 1 },
+  ],
+}
+
+test("strips title line and emits IR", () => {
+  const post = transformPage(page)
+  expect(post.id).toBe("0123456789abcdef01234567")
+  expect(post.title).toBe("First Post")
+  expect(post.createdAt.toISOString()).toBe(new Date(1714521600 * 1000).toISOString())
+  expect(post.description).toBe("Intro paragraph.")
+  expect(post.tags).toEqual(["blog", "demo"])
+  expect(post.body).toContain("Intro paragraph.")
+  expect(post.body).not.toContain("First Post\n")
+  expect(post.images).toEqual([
+    { url: "https://gyazo.com/ABCDEF123456.png", filename: "ABCDEF123456.png" },
+  ])
+})
+
+test("description falls back to empty string when body has no prose", () => {
+  const post = transformPage({ ...page, lines: [page.lines[0]] })
+  expect(post.description).toBe("")
+})
+```
+
+Run: `pnpm test:unit lib/sync/transform.test.ts` → red.
+
+- [ ] **Step 2: Implement**
+
+```ts
+// lib/sync/transform.ts
+import { scrapboxToMarkdown } from "./scrapbox-to-md"
+import type { CosensePage, ImageRef, Post } from "./types"
+
+const HASHTAG_RE = /(?:^|\s)#([\p{L}\p{N}_-]+)/gu
+const GYAZO_RE = /\[https:\/\/gyazo\.com\/([a-zA-Z0-9]+)(\.[a-z]+)?\]/g
+const SCRAPBOX_FILE_RE = /\[https:\/\/scrapbox\.io\/files\/([a-zA-Z0-9]+\.[a-z]+)\]/g
+
+function extractTags(text: string): string[] {
+  const out = new Set<string>()
+  for (const m of text.matchAll(HASHTAG_RE)) out.add(m[1])
+  return [...out]
+}
+
+function extractImages(text: string): ImageRef[] {
+  const out: ImageRef[] = []
+  for (const m of text.matchAll(GYAZO_RE)) {
+    const ext = m[2] ?? ".png"
+    out.push({ url: `https://gyazo.com/${m[1]}${ext}`, filename: `${m[1]}${ext}` })
+  }
+  for (const m of text.matchAll(SCRAPBOX_FILE_RE)) {
+    out.push({
+      url: `https://scrapbox.io/files/${m[1]}`,
+      filename: m[1],
+    })
+  }
+  return out
+}
+
+function firstProseLine(bodyLines: string[]): string {
+  for (const l of bodyLines) {
+    const trimmed = l.trim()
+    if (trimmed.length === 0) continue
+    if (trimmed.startsWith("#")) continue          // hashtag-only line
+    if (trimmed.startsWith("[")) continue          // image / heading line
+    return trimmed.length > 160 ? trimmed.slice(0, 160) : trimmed
+  }
+  return ""
+}
+
+export function transformPage(page: CosensePage): Post {
+  const bodyLines = page.lines.slice(1).map((l) => l.text)
+  const rawBody = bodyLines.join("\n")
+  return {
+    id: page.id,
+    title: page.title,
+    createdAt: new Date(page.created * 1000),
+    updatedAt: new Date(page.updated * 1000),
+    description: firstProseLine(bodyLines),
+    tags: extractTags(rawBody),
+    body: scrapboxToMarkdown(rawBody),
+    images: extractImages(rawBody),
+  }
+}
+```
+
+Run: `pnpm test:unit lib/sync/transform.test.ts` → green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/sync/transform.ts lib/sync/transform.test.ts
+git commit -m "Add Cosense page -> IR transform"
+```
+
+---
+
+## Task 8: Image downloader (`lib/sync/images.ts`)
+
+**Files:**
+- Create: `lib/sync/images.test.ts`
+- Create: `lib/sync/images.ts`
+
+Idempotent: if the file already exists with matching size, do not refetch. Errors are surfaced (caller decides to skip the page).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// lib/sync/images.test.ts
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, expect, test, vi } from "vitest"
+import { downloadImages } from "./images"
+
+let dir: string
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "sync-img-")) })
+afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+test("downloads each image once", async () => {
+  const fetchMock = vi.fn().mockResolvedValue(
+    new Response(new Uint8Array([1, 2, 3]), { status: 200 }),
+  )
+  await downloadImages(
+    [
+      { url: "https://gyazo.com/a.png", filename: "a.png" },
+      { url: "https://gyazo.com/b.png", filename: "b.png" },
+    ],
+    dir,
+    { fetch: fetchMock },
+  )
+  expect(fetchMock).toHaveBeenCalledTimes(2)
+  expect(readFileSync(join(dir, "a.png"))).toEqual(new Uint8Array([1, 2, 3]))
+  expect(readFileSync(join(dir, "b.png"))).toEqual(new Uint8Array([1, 2, 3]))
+})
+
+test("skips files that already exist", async () => {
+  writeFileSync(join(dir, "a.png"), new Uint8Array([9]))
+  const fetchMock = vi.fn().mockResolvedValue(
+    new Response(new Uint8Array([1]), { status: 200 }),
+  )
+  await downloadImages(
+    [{ url: "https://gyazo.com/a.png", filename: "a.png" }],
+    dir,
+    { fetch: fetchMock },
+  )
+  expect(fetchMock).not.toHaveBeenCalled()
+  expect(statSync(join(dir, "a.png")).size).toBe(1)
+})
+
+test("propagates fetch failure", async () => {
+  const fetchMock = vi.fn().mockResolvedValue(new Response("nope", { status: 404 }))
+  await expect(
+    downloadImages(
+      [{ url: "https://gyazo.com/a.png", filename: "a.png" }],
+      dir,
+      { fetch: fetchMock },
+    ),
+  ).rejects.toThrow(/404/)
+})
+```
+
+Run: `pnpm test:unit lib/sync/images.test.ts` → red.
+
+- [ ] **Step 2: Implement**
+
+```ts
+// lib/sync/images.ts
+import { existsSync } from "node:fs"
+import { writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import type { ImageRef } from "./types"
+
+export interface DownloadOptions {
+  fetch?: typeof globalThis.fetch
+}
+
+export async function downloadImages(
+  refs: ImageRef[],
+  targetDir: string,
+  opts: DownloadOptions = {},
+): Promise<void> {
+  const fetcher = opts.fetch ?? globalThis.fetch
+  for (const ref of refs) {
+    const dest = join(targetDir, ref.filename)
+    if (existsSync(dest)) continue
+    const r = await fetcher(ref.url)
+    if (!r.ok) throw new Error(`image fetch ${ref.url} -> ${r.status}`)
+    const buf = new Uint8Array(await r.arrayBuffer())
+    await writeFile(dest, buf)
+  }
+}
+```
+
+Run: `pnpm test:unit lib/sync/images.test.ts` → green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/sync/images.ts lib/sync/images.test.ts
+git commit -m "Add idempotent image downloader for Cosense images"
+```
+
+---
+
+## Task 9: Idempotent fs writer (`lib/sync/fs-writer.ts`)
+
+**Files:**
+- Create: `lib/sync/fs-writer.test.ts`
+- Create: `lib/sync/fs-writer.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// lib/sync/fs-writer.test.ts
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, expect, test } from "vitest"
+import { writePost, deletePost } from "./fs-writer"
+import type { Post } from "./types"
+
+let root: string
+beforeEach(() => { root = mkdtempSync(join(tmpdir(), "sync-fs-")) })
+afterEach(() => { rmSync(root, { recursive: true, force: true }) })
+
+const post: Post = {
+  id: "0123456789abcdef01234567",
+  title: "Sample",
+  createdAt: new Date("2026-05-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-05-04T00:00:00.000Z"),
+  description: "intro",
+  tags: [],
+  body: "Hello body.",
+  images: [],
+}
+
+test("writes index.md under content/posts/<id>/", async () => {
+  await writePost(post, root)
+  const out = readFileSync(join(root, post.id, "index.md"), "utf8")
+  expect(out).toContain("title: Sample")
+  expect(out).toContain("\n\nHello body.\n")
+})
+
+test("second write with identical content does not change mtime", async () => {
+  await writePost(post, root)
+  const dest = join(root, post.id, "index.md")
+  const t1 = statSync(dest).mtimeMs
+  await new Promise((r) => setTimeout(r, 20))
+  await writePost(post, root)
+  expect(statSync(dest).mtimeMs).toBe(t1)
+})
+
+test("write with changed content overwrites", async () => {
+  await writePost(post, root)
+  await writePost({ ...post, body: "Different." }, root)
+  expect(readFileSync(join(root, post.id, "index.md"), "utf8")).toContain("Different.")
+})
+
+test("deletePost removes the directory", async () => {
+  writeFileSync(join(root, "to-delete.md"), "x") // noise: stays
+  await writePost(post, root)
+  await deletePost(post.id, root)
+  expect(() => statSync(join(root, post.id))).toThrow()
+  expect(readFileSync(join(root, "to-delete.md"), "utf8")).toBe("x")
+})
+```
+
+Run: `pnpm test:unit lib/sync/fs-writer.test.ts` → red.
+
+- [ ] **Step 2: Implement**
+
+```ts
+// lib/sync/fs-writer.ts
+import { existsSync } from "node:fs"
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import { emitFrontmatter } from "./frontmatter"
+import type { Post } from "./types"
+
+function render(post: Post): string {
+  const front = emitFrontmatter(post)
+  const body = post.body.endsWith("\n") ? post.body : `${post.body}\n`
+  return `${front}\n${body}`
+}
+
+export async function writePost(post: Post, postsRoot: string): Promise<void> {
+  const dir = join(postsRoot, post.id)
+  await mkdir(dir, { recursive: true })
+  const dest = join(dir, "index.md")
+  const next = render(post)
+  if (existsSync(dest)) {
+    const cur = await readFile(dest, "utf8")
+    if (cur === next) return
+  }
+  await writeFile(dest, next)
+}
+
+export async function deletePost(id: string, postsRoot: string): Promise<void> {
+  const dir = join(postsRoot, id)
+  if (!existsSync(dir)) return
+  await rm(dir, { recursive: true, force: true })
+}
+```
+
+Run: `pnpm test:unit lib/sync/fs-writer.test.ts` → green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/sync/fs-writer.ts lib/sync/fs-writer.test.ts
+git commit -m "Add idempotent post writer + deletePost"
+```
+
+---
+
+## Task 10: Redirects emitter (`lib/sync/redirects.ts`)
+
+**Files:**
+- Create: `lib/sync/redirects.test.ts`
+- Create: `lib/sync/redirects.ts`
+
+The seed file lives in Phase 2; this module accepts the parsed seed array and emits the body of `public/_redirects`. Empty seed → empty string (caller skips file write).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// lib/sync/redirects.test.ts
+import { describe, expect, test } from "vitest"
+import { emitRedirects, type RedirectSeedEntry } from "./redirects"
+
+describe("emitRedirects", () => {
+  test("empty seed -> empty string", () => {
+    expect(emitRedirects([])).toBe("")
+  })
+
+  test("emits one 308 line per entry", () => {
+    const seed: RedirectSeedEntry[] = [
+      { old_path: "/2025-purchases", new_id: "0123456789abcdef01234567" },
+      { old_path: "/php-replace-lf", new_id: "fedcba9876543210fedcba98" },
+    ]
+    expect(emitRedirects(seed)).toBe(
+      [
+        "/2025-purchases /0123456789abcdef01234567/ 308",
+        "/php-replace-lf /fedcba9876543210fedcba98/ 308",
+        "",
+      ].join("\n"),
+    )
+  })
+
+  test("throws on duplicate old_path", () => {
+    expect(() =>
+      emitRedirects([
+        { old_path: "/x", new_id: "0123456789abcdef01234567" },
+        { old_path: "/x", new_id: "fedcba9876543210fedcba98" },
+      ]),
+    ).toThrow(/duplicate/i)
+  })
+})
+```
+
+Run: `pnpm test:unit lib/sync/redirects.test.ts` → red.
+
+- [ ] **Step 2: Implement**
+
+```ts
+// lib/sync/redirects.ts
+export interface RedirectSeedEntry {
+  old_path: string
+  new_id: string
+}
+
+export function emitRedirects(seed: RedirectSeedEntry[]): string {
+  if (seed.length === 0) return ""
+  const seen = new Set<string>()
+  const lines: string[] = []
+  for (const entry of seed) {
+    if (seen.has(entry.old_path)) {
+      throw new Error(`duplicate old_path in redirects seed: ${entry.old_path}`)
+    }
+    seen.add(entry.old_path)
+    lines.push(`${entry.old_path} /${entry.new_id}/ 308`)
+  }
+  lines.push("")
+  return lines.join("\n")
+}
+```
+
+Run: `pnpm test:unit lib/sync/redirects.test.ts` → green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/sync/redirects.ts lib/sync/redirects.test.ts
+git commit -m "Add Cloudflare _redirects emitter (308 with empty-seed handling)"
+```
+
+---
+
+## Task 11: Diff classifier (`lib/sync/diff.ts`)
+
+**Files:**
+- Create: `lib/sync/diff.test.ts`
+- Create: `lib/sync/diff.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// lib/sync/diff.test.ts
+import { describe, expect, test } from "vitest"
+import { computePlan, type LocalPostState } from "./diff"
+import type { CosenseListEntry } from "./types"
+
+const remote: CosenseListEntry[] = [
+  { id: "0123456789abcdef01234567", title: "A", updated: 1000 },
+  { id: "fedcba9876543210fedcba98", title: "B", updated: 2000 },
+]
+
+describe("computePlan", () => {
+  test("empty local -> all create", () => {
+    const plan = computePlan(remote, [])
+    expect(plan.actions.map((a) => a.kind).sort()).toEqual(["create", "create"])
+    expect(plan.localCount).toBe(0)
+  })
+
+  test("local matches remote with same updated -> unchanged", () => {
+    const local: LocalPostState[] = [
+      { id: "0123456789abcdef01234567", updatedAt: new Date(1000 * 1000) },
+      { id: "fedcba9876543210fedcba98", updatedAt: new Date(2000 * 1000) },
+    ]
+    const plan = computePlan(remote, local)
+    expect(plan.actions.every((a) => a.kind === "unchanged")).toBe(true)
+  })
+
+  test("remote.updated newer -> update", () => {
+    const local: LocalPostState[] = [
+      { id: "0123456789abcdef01234567", updatedAt: new Date(500 * 1000) },
+      { id: "fedcba9876543210fedcba98", updatedAt: new Date(2000 * 1000) },
+    ]
+    const plan = computePlan(remote, local)
+    const update = plan.actions.find((a) => a.kind === "update")
+    expect(update).toBeDefined()
+    if (update?.kind === "update") expect(update.page.id).toBe("0123456789abcdef01234567")
+  })
+
+  test("local entry not in remote -> delete", () => {
+    const local: LocalPostState[] = [
+      { id: "0123456789abcdef01234567", updatedAt: new Date(1000 * 1000) },
+      { id: "ffffffffffffffffffffffff", updatedAt: new Date(0) },
+    ]
+    const plan = computePlan(remote, local)
+    expect(plan.actions.find((a) => a.kind === "delete")).toEqual({
+      kind: "delete",
+      id: "ffffffffffffffffffffffff",
+    })
+  })
+})
+```
+
+Run: `pnpm test:unit lib/sync/diff.test.ts` → red.
+
+- [ ] **Step 2: Implement**
+
+```ts
+// lib/sync/diff.ts
+import type { CosenseListEntry, SyncAction, SyncPlan } from "./types"
+
+export interface LocalPostState {
+  id: string
+  updatedAt: Date
+}
+
+export function computePlan(
+  remote: CosenseListEntry[],
+  local: LocalPostState[],
+): SyncPlan {
+  const actions: SyncAction[] = []
+  const localById = new Map(local.map((l) => [l.id, l]))
+  for (const page of remote) {
+    const cur = localById.get(page.id)
+    if (!cur) {
+      actions.push({ kind: "create", page })
+    } else if (Math.floor(cur.updatedAt.getTime() / 1000) < page.updated) {
+      actions.push({ kind: "update", page })
+    } else {
+      actions.push({ kind: "unchanged", id: page.id })
+    }
+    localById.delete(page.id)
+  }
+  for (const stale of localById.keys()) {
+    actions.push({ kind: "delete", id: stale })
+  }
+  return { actions, localCount: local.length }
+}
+```
+
+Run: `pnpm test:unit lib/sync/diff.test.ts` → green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/sync/diff.ts lib/sync/diff.test.ts
+git commit -m "Add diff classifier (create/update/unchanged/delete)"
+```
+
+---
+
+## Task 12: Orchestrator + CLI (`scripts/sync-cosense.ts`)
+
+**Files:**
+- Create: `scripts/sync-cosense.ts`
+
+Reads env, flags, the local state, calls the client, runs diff, executes per-page work, writes redirects, prints a summary. Stays under ~120 lines.
+
+- [ ] **Step 1: Implement (no TDD here — task 13 is the integration test)**
+
+```ts
+// scripts/sync-cosense.ts
+import { readdir, readFile, writeFile } from "node:fs/promises"
+import { join, resolve } from "node:path"
+import matter from "gray-matter"
+import { z } from "zod"
+import { CosenseClient } from "@/lib/sync/cosense-client"
+import { computePlan, type LocalPostState } from "@/lib/sync/diff"
+import { writePost, deletePost } from "@/lib/sync/fs-writer"
+import { downloadImages } from "@/lib/sync/images"
+import { emitRedirects, type RedirectSeedEntry } from "@/lib/sync/redirects"
+import { transformPage } from "@/lib/sync/transform"
+
+const envSchema = z.object({
+  COSENSE_PROJECT: z.string().min(1),
+  COSENSE_SID: z.string().min(1),
+  MAX_DELETE_RATIO: z.coerce.number().min(0).max(1).default(0.5),
+})
+
+const POSTS_ROOT = resolve(process.cwd(), "content/posts")
+const REDIRECTS_PATH = resolve(process.cwd(), "public/_redirects")
+const SEED_PATH = resolve(process.cwd(), "lib/sync/redirects-seed.json")
+
+interface Args { dryRun: boolean }
+function parseArgs(argv: string[]): Args {
+  return { dryRun: argv.includes("--dry-run") || process.env.SYNC_DRY_RUN === "true" }
+}
+
+async function readLocalState(): Promise<LocalPostState[]> {
+  let entries: string[]
+  try { entries = await readdir(POSTS_ROOT) } catch { return [] }
+  const out: LocalPostState[] = []
+  for (const id of entries) {
+    if (!/^[a-f0-9]{24}$/.test(id)) continue
+    const front = matter(await readFile(join(POSTS_ROOT, id, "index.md"), "utf8")).data
+    if (typeof front.updated_at !== "string") continue
+    out.push({ id, updatedAt: new Date(front.updated_at) })
+  }
+  return out
+}
+
+async function readSeed(): Promise<RedirectSeedEntry[]> {
+  try { return JSON.parse(await readFile(SEED_PATH, "utf8")) } catch { return [] }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+  const env = envSchema.parse(process.env)
+
+  const client = new CosenseClient({ project: env.COSENSE_PROJECT, sid: env.COSENSE_SID })
+  const list = await client.listPages()
+  const local = await readLocalState()
+  const plan = computePlan(list.pages, local)
+
+  const deletions = plan.actions.filter((a) => a.kind === "delete").length
+  if (plan.localCount > 0 && deletions / plan.localCount > env.MAX_DELETE_RATIO) {
+    throw new Error(`abort: would delete ${deletions}/${plan.localCount} posts`)
+  }
+
+  console.log(`plan: ${plan.actions.map((a) => a.kind).join(",")}`)
+
+  if (args.dryRun) {
+    await writeFile(
+      resolve(process.cwd(), ".sync-plan.json"),
+      JSON.stringify(plan, null, 2),
+    )
+    return
+  }
+
+  for (const action of plan.actions) {
+    if (action.kind === "delete") {
+      await deletePost(action.id, POSTS_ROOT)
+      continue
+    }
+    if (action.kind === "unchanged") continue
+    const page = await client.getPage(action.page.title)
+    const post = transformPage(page)
+    await downloadImages(post.images, join(POSTS_ROOT, post.id))
+    await writePost(post, POSTS_ROOT)
+  }
+
+  const redirects = emitRedirects(await readSeed())
+  if (redirects.length > 0) await writeFile(REDIRECTS_PATH, redirects)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})
+```
+
+- [ ] **Step 2: Verify it type-checks**
+
+Run: `pnpm test`
+Expected: PASS (tsc).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/sync-cosense.ts
+git commit -m "Add sync orchestrator (CLI entry point)"
+```
+
+---
+
+## Task 13: Orchestrator integration test (`scripts/sync-cosense.test.ts`)
+
+**Files:**
+- Create: `scripts/sync-cosense.test.ts`
+
+We test the orchestrator end-to-end against a stubbed client + tmp dir, NOT by spawning a subprocess. To do this we extract the orchestration body into a runnable function.
+
+- [ ] **Step 1: Refactor `scripts/sync-cosense.ts` to export a `runSync()` function**
+
+Restructure so the file ends like this (replacing the previous `main` + `.catch` block):
+
+```ts
+export interface RunOptions {
+  client: { listPages: CosenseClient["listPages"]; getPage: CosenseClient["getPage"] }
+  postsRoot: string
+  redirectsPath: string
+  seed: RedirectSeedEntry[]
+  maxDeleteRatio: number
+  dryRun: boolean
+  fetch?: typeof globalThis.fetch
+}
+
+export async function runSync(opts: RunOptions): Promise<{ plan: ReturnType<typeof computePlan> }> {
+  const list = await opts.client.listPages()
+  const local = await readLocalStateAt(opts.postsRoot)
+  const plan = computePlan(list.pages, local)
+
+  const deletions = plan.actions.filter((a) => a.kind === "delete").length
+  if (plan.localCount > 0 && deletions / plan.localCount > opts.maxDeleteRatio) {
+    throw new Error(`abort: would delete ${deletions}/${plan.localCount} posts`)
+  }
+
+  if (opts.dryRun) return { plan }
+
+  for (const action of plan.actions) {
+    if (action.kind === "delete") {
+      await deletePost(action.id, opts.postsRoot)
+      continue
+    }
+    if (action.kind === "unchanged") continue
+    const page = await opts.client.getPage(action.page.title)
+    const post = transformPage(page)
+    const postDir = join(opts.postsRoot, post.id)
+    await mkdir(postDir, { recursive: true })
+    await downloadImages(post.images, postDir, { fetch: opts.fetch })
+    await writePost(post, opts.postsRoot)
+  }
+
+  const redirects = emitRedirects(opts.seed)
+  if (redirects.length > 0) await writeFile(opts.redirectsPath, redirects)
+  return { plan }
+}
+
+async function readLocalStateAt(postsRoot: string): Promise<LocalPostState[]> {
+  let entries: string[]
+  try { entries = await readdir(postsRoot) } catch { return [] }
+  const out: LocalPostState[] = []
+  for (const id of entries) {
+    if (!/^[a-f0-9]{24}$/.test(id)) continue
+    const front = matter(await readFile(join(postsRoot, id, "index.md"), "utf8")).data
+    if (typeof front.updated_at !== "string") continue
+    out.push({ id, updatedAt: new Date(front.updated_at) })
+  }
+  return out
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const args = parseArgs(process.argv.slice(2))
+  const env = envSchema.parse(process.env)
+  const seed = await readSeed()
+  await runSync({
+    client: new CosenseClient({ project: env.COSENSE_PROJECT, sid: env.COSENSE_SID }),
+    postsRoot: POSTS_ROOT,
+    redirectsPath: REDIRECTS_PATH,
+    seed,
+    maxDeleteRatio: env.MAX_DELETE_RATIO,
+    dryRun: args.dryRun,
+  }).catch((err) => { console.error(err); process.exit(1) })
+}
+```
+
+Add `mkdir` to the existing `node:fs/promises` import. Remove the previous `main()` definition and its `.catch` handler.
+
+- [ ] **Step 2: Write the integration test**
+
+```ts
+// scripts/sync-cosense.test.ts
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs"
+import { mkdir } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { afterEach, beforeEach, expect, test, vi } from "vitest"
+import { runSync } from "./sync-cosense"
+
+const listJson = JSON.parse(
+  readFileSync(resolve(__dirname, "../lib/sync/__fixtures__/pages-list.json"), "utf8"),
+)
+const detailJson = JSON.parse(
+  readFileSync(resolve(__dirname, "../lib/sync/__fixtures__/page-detail.json"), "utf8"),
+)
+
+let root: string
+beforeEach(() => { root = mkdtempSync(join(tmpdir(), "sync-int-")) })
+afterEach(() => { rmSync(root, { recursive: true, force: true }) })
+
+const stubClient = (detail = detailJson) => ({
+  listPages: vi.fn().mockResolvedValue(listJson),
+  getPage: vi.fn().mockResolvedValue(detail),
+})
+
+test("dry-run produces a plan without touching disk", async () => {
+  const c = stubClient()
+  const r = await runSync({
+    client: c,
+    postsRoot: join(root, "posts"),
+    redirectsPath: join(root, "_redirects"),
+    seed: [],
+    maxDeleteRatio: 0.5,
+    dryRun: true,
+  })
+  expect(r.plan.actions.map((a) => a.kind).sort()).toEqual(["create", "create"])
+  expect(c.getPage).not.toHaveBeenCalled()
+  expect(readdirSync(root)).toEqual([])
+})
+
+test("real run creates post directories and is idempotent", async () => {
+  const c = stubClient()
+  const fetchStub = vi.fn().mockResolvedValue(
+    new Response(new Uint8Array([1]), { status: 200 }),
+  )
+  await mkdir(join(root, "posts"), { recursive: true })
+  await runSync({
+    client: c,
+    postsRoot: join(root, "posts"),
+    redirectsPath: join(root, "_redirects"),
+    seed: [],
+    maxDeleteRatio: 0.5,
+    dryRun: false,
+    fetch: fetchStub,
+  })
+  const id = listJson.pages[0].id
+  expect(readFileSync(join(root, "posts", id, "index.md"), "utf8")).toContain(`path: /${id}`)
+
+  // second run is a no-op
+  c.getPage.mockClear()
+  await runSync({
+    client: stubClient(),
+    postsRoot: join(root, "posts"),
+    redirectsPath: join(root, "_redirects"),
+    seed: [],
+    maxDeleteRatio: 0.5,
+    dryRun: false,
+    fetch: fetchStub,
+  })
+  // both pages now appear unchanged based on frontmatter updated_at
+})
+
+test("aborts when deletes exceed ratio", async () => {
+  await mkdir(join(root, "posts", "deadbeefdeadbeefdeadbeef"), { recursive: true })
+  writeFileSync(
+    join(root, "posts", "deadbeefdeadbeefdeadbeef", "index.md"),
+    `---\nupdated_at: '2026-01-01T00:00:00.000Z'\n---\n`,
+  )
+  await mkdir(join(root, "posts", "cafebabecafebabecafebabe"), { recursive: true })
+  writeFileSync(
+    join(root, "posts", "cafebabecafebabecafebabe", "index.md"),
+    `---\nupdated_at: '2026-01-01T00:00:00.000Z'\n---\n`,
+  )
+  // Stub returns the canned listJson which doesn't contain either local id,
+  // so both will be classified as delete. 2/2 = 1.0 > 0.5 → abort.
+  await expect(
+    runSync({
+      client: stubClient(),
+      postsRoot: join(root, "posts"),
+      redirectsPath: join(root, "_redirects"),
+      seed: [],
+      maxDeleteRatio: 0.5,
+      dryRun: false,
+    }),
+  ).rejects.toThrow(/would delete/)
+})
+```
+
+- [ ] **Step 3: Run, then fix any small refactor issues**
+
+Run: `pnpm test:unit scripts/sync-cosense.test.ts`
+Expected: green. If a test fails because the orchestrator imports `gray-matter` (already a project dep, see `package.json`), that's expected to work — it's used elsewhere in the build.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/sync-cosense.ts scripts/sync-cosense.test.ts
+git commit -m "Make sync orchestrator testable; add integration tests"
+```
+
+---
+
+## Task 14: GitHub Actions workflow (manual only in Phase 1)
+
+**Files:**
+- Create: `.github/workflows/sync.yml`
+- Modify: `.github/workflows/test.yml`
+
+The cron schedule is intentionally left out of Phase 1. Phase 2 enables it after migration data is in place.
+
+- [ ] **Step 1: Create `sync.yml`**
+
+```yaml
+name: Sync from Cosense
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry-run only (writes .sync-plan.json, no commit)"
+        required: false
+        default: "false"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+      - run: corepack enable
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: ./.node-version
+          cache: "pnpm"
+      - run: pnpm install --frozen-lockfile
+      - name: Run sync
+        run: pnpm sync ${{ inputs.dry_run == 'true' && '--dry-run' || '' }}
+        env:
+          COSENSE_PROJECT: ${{ secrets.COSENSE_PROJECT }}
+          COSENSE_SID:     ${{ secrets.COSENSE_SID }}
+      - name: Commit & push (skipped on dry-run)
+        if: inputs.dry_run != 'true'
+        run: |
+          if [ -n "$(git status --porcelain content public)" ]; then
+            git config user.name  "blog-sync[bot]"
+            git config user.email "blog-sync@users.noreply.github.com"
+            git add content public
+            git commit -m "sync: pull from Cosense"
+            git push origin main
+          fi
+      - name: Upload dry-run plan
+        if: inputs.dry_run == 'true' && hashFiles('.sync-plan.json') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: sync-plan
+          path: .sync-plan.json
+```
+
+- [ ] **Step 2: Add a vitest step to `test.yml`**
+
+In `.github/workflows/test.yml`, after the existing `- run: pnpm test` line and BEFORE the "Verify dist artifacts" step, insert:
+
+```yaml
+      - run: pnpm test:unit
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/sync.yml .github/workflows/test.yml
+git commit -m "Add manual Cosense sync workflow + wire vitest into CI"
+```
+
+---
+
+## Task 15: Acceptance check
+
+**Files:** none modified.
+
+- [ ] **Step 1: Lint and full test sweep**
+
+```bash
+pnpm lint:ci
+pnpm test
+pnpm test:unit
+```
+
+All three must pass. If `lint:ci` complains, run `pnpm lint` and re-stage.
+
+- [ ] **Step 2: Local dry-run against a real test Cosense project**
+
+This is the Phase 1 acceptance gate from the spec. The author creates a small test Cosense project (any name, any 1–3 pages) and exports `COSENSE_PROJECT` / `COSENSE_SID` locally.
+
+```bash
+export COSENSE_PROJECT=...
+export COSENSE_SID=...
+pnpm sync --dry-run
+cat .sync-plan.json
+```
+
+Expected: `.sync-plan.json` lists one `create` per Cosense page, `localCount: 0`. No files under `content/posts/` are touched.
+
+- [ ] **Step 3: PR**
+
+Open a PR from this branch to `main`. Title: `feat: Cosense source-of-truth — Phase 1 sync engine`. Body: link the spec, summarize that no live data is changed (workflow is `workflow_dispatch` only, cron is Phase 2). Mention that secrets `COSENSE_PROJECT` and `COSENSE_SID` need to be added to the GitHub repo settings before the workflow can be exercised end-to-end.
+
+- [ ] **Step 4: After merge**
+
+Verify in the GitHub Actions UI that "Sync from Cosense" appears under workflows and can be triggered via "Run workflow" with `dry_run: true`. The artifact `sync-plan` should be downloadable and contain the same JSON shape as the local dry-run.
+
+---
+
+## Self-review notes (for the implementer)
+
+- The orchestrator imports `gray-matter` — that's an existing dep used by Velite's content layer, so it's safe to use.
+- `import.meta.url === \`file://${process.argv[1]}\`` is the standard "is this script run directly under tsx?" idiom; if it doesn't trigger when run via `pnpm sync`, fall back to gating with `process.env.NODE_ENV !== "test"` and call `runSync(...)` from the script body unconditionally outside tests.
+- The integration test in Task 13 stubs the client object directly rather than spawning a subprocess. Do not be tempted to spawn `tsx scripts/sync-cosense.ts` — it adds 2-3 s per test for no signal gain.
+- If the Scrapbox notation table grows past ~15 rows, split the table tests into thematic `describe` blocks but keep the data-driven structure.
+- `lib/sync/redirects-seed.json` is intentionally absent from this plan. Phase 2 creates it.
+
+### Deliberate deviations from the spec
+
+- **Per-page error tolerance is deferred.** The spec describes a `.sync-errors.json` file and a "skip page, continue" policy for parse / image / schema failures. Phase 1's orchestrator throws on the first per-page failure, which aborts the whole run. This is acceptable while the workflow is `workflow_dispatch` only (operator sees the failure immediately and re-runs). Phase 2 must add the per-page tolerance before the cron is enabled, otherwise a single broken page will block all subsequent syncs.
+- **Pre-write `postSchema` validation is not implemented.** Phase 1 relies on the existing `pnpm build` (run by Cloudflare Pages or in CI) to catch schema drift. This is fine because Phase 1 doesn't run sync against `main` automatically.
+- **Cron schedule is not enabled.** `sync.yml` ships with `workflow_dispatch:` only. Phase 2 adds `schedule:` after migration data lands.

--- a/docs/superpowers/plans/2026-05-04-cosense-sync-phase-1.md
+++ b/docs/superpowers/plans/2026-05-04-cosense-sync-phase-1.md
@@ -792,6 +792,46 @@ test("description falls back to empty string when body has no prose", () => {
   const post = transformPage({ ...page, lines: [page.lines[0]] })
   expect(post.description).toBe("")
 })
+
+test("description skips code: and blockquote lines", () => {
+  const post = transformPage({
+    ...page,
+    lines: [
+      page.lines[0],
+      { id: "x", text: "code:hello.ts", userId: "u", created: 1, updated: 1 },
+      { id: "y", text: " const x = 1", userId: "u", created: 1, updated: 1 },
+      { id: "z", text: "> quoted", userId: "u", created: 1, updated: 1 },
+      { id: "w", text: "real prose here", userId: "u", created: 1, updated: 1 },
+    ],
+  })
+  expect(post.description).toBe("real prose here")
+})
+
+test("does not eat first body line when title differs from lines[0]", () => {
+  const post = transformPage({
+    ...page,
+    title: "Renamed",
+    lines: [
+      { id: "l1", text: "Original Body Line", userId: "u", created: 1, updated: 1 },
+      { id: "l2", text: "Second", userId: "u", created: 1, updated: 1 },
+    ],
+  })
+  expect(post.description).toBe("Original Body Line")
+  expect(post.body).toContain("Original Body Line")
+})
+
+test("hashtag dedup + scrapbox file image", () => {
+  const post = transformPage({
+    ...page,
+    lines: [
+      page.lines[0],
+      { id: "a", text: "see #blog and #blog again", userId: "u", created: 1, updated: 1 },
+      { id: "b", text: "[https://scrapbox.io/files/abc.jpg]", userId: "u", created: 1, updated: 1 },
+    ],
+  })
+  expect(post.tags).toEqual(["blog"])
+  expect(post.images).toEqual([{ url: "https://scrapbox.io/files/abc.jpg", filename: "abc.jpg" }])
+})
 ```
 
 Run: `pnpm test:unit lib/sync/transform.test.ts` → red.
@@ -806,6 +846,8 @@ import type { CosensePage, ImageRef, Post } from "./types"
 const HASHTAG_RE = /(?:^|\s)#([\p{L}\p{N}_-]+)/gu
 const GYAZO_RE = /\[https:\/\/gyazo\.com\/([a-zA-Z0-9]+)(\.[a-z]+)?\]/g
 const SCRAPBOX_FILE_RE = /\[https:\/\/scrapbox\.io\/files\/([a-zA-Z0-9]+\.[a-z]+)\]/g
+
+const DESCRIPTION_MAX = 160
 
 function extractTags(text: string): string[] {
   const out = new Set<string>()
@@ -833,14 +875,18 @@ function firstProseLine(bodyLines: string[]): string {
     const trimmed = l.trim()
     if (trimmed.length === 0) continue
     if (trimmed.startsWith("#")) continue          // hashtag-only line
-    if (trimmed.startsWith("[")) continue          // image / heading line
-    return trimmed.length > 160 ? trimmed.slice(0, 160) : trimmed
+    if (trimmed.startsWith("[")) continue          // image / heading / link line
+    if (trimmed.startsWith("code:")) continue      // fenced-code opener
+    if (trimmed.startsWith(">")) continue          // blockquote
+    if (l !== trimmed && trimmed.length > 0) continue // indented line (code content)
+    return trimmed.length > DESCRIPTION_MAX ? trimmed.slice(0, DESCRIPTION_MAX) : trimmed
   }
   return ""
 }
 
 export function transformPage(page: CosensePage): Post {
-  const bodyLines = page.lines.slice(1).map((l) => l.text)
+  const skipTitle = page.lines[0]?.text === page.title ? 1 : 0
+  const bodyLines = page.lines.slice(skipTitle).map((l) => l.text)
   const rawBody = bodyLines.join("\n")
   return {
     id: page.id,

--- a/docs/superpowers/plans/2026-05-04-cosense-sync-phase-1.md
+++ b/docs/superpowers/plans/2026-05-04-cosense-sync-phase-1.md
@@ -254,6 +254,9 @@ describe("scrapboxToMarkdown", () => {
     ["scrapbox image", "[https://scrapbox.io/files/xyz.png]", "![](xyz.png)"],
     ["internal link",  "[Other Page]",                    "**Other Page**"],
     ["blockquote",     "> quoted",                         "> quoted"],
+    ["heading clamps 5+ stars to h1", "[***** mega]",     "# mega"],
+    ["whitespace-only bracket stays as-is", "[   ]",      "[   ]"],
+    ["bare url with trailing period", "[https://example.com.]", "<https://example.com>."],
   ]
   for (const [label, input, expected] of cases) {
     test(label, () => {
@@ -293,13 +296,13 @@ Create `lib/sync/scrapbox-to-md.ts`:
 // the test table covers. New notation discovered in real Cosense
 // content adds a row to the table FIRST, then is implemented here.
 
-const HEADING_LEVELS: Record<number, string> = { 4: "#", 3: "##", 2: "###" }
+const HEADING_LEVELS: Record<2 | 3 | 4, string> = { 4: "#", 3: "##", 2: "###" }
 
 const GYAZO_RE = /^\[https:\/\/gyazo\.com\/([a-zA-Z0-9]+)(?:\.[a-z]+)?\]$/
 const SCRAPBOX_FILE_RE =
   /^\[https:\/\/scrapbox\.io\/files\/([a-zA-Z0-9]+\.[a-z]+)\]$/
 const URL_TITLE_RE = /^\[(https?:\/\/\S+)\s+(.+)\]$/
-const URL_BARE_RE = /^\[(https?:\/\/\S+)\]$/
+const URL_BARE_RE = /^\[(https?:\/\/[^\s\]]+?)([.,;:!?]?)\]$/
 const STAR_RE = /^\[(\*+)\s+(.+)\]$/
 const INTERNAL_RE = /^\[([^\]]+)\]$/
 const CODE_OPEN_RE = /^code:([^\s]+)$/
@@ -310,14 +313,17 @@ function transformInline(line: string): string {
   if ((m = line.match(GYAZO_RE))) return `![](${m[1]}.png)`
   if ((m = line.match(SCRAPBOX_FILE_RE))) return `![](${m[1]})`
   if ((m = line.match(URL_TITLE_RE))) return `[${m[2]}](${m[1]})`
-  if ((m = line.match(URL_BARE_RE))) return `<${m[1]}>`
+  if ((m = line.match(URL_BARE_RE))) return `<${m[1]}>${m[2]}`
   if ((m = line.match(STAR_RE))) {
     const stars = m[1].length
     const text = m[2]
-    return stars === 1 ? `**${text}**` : `${HEADING_LEVELS[stars] ?? "###"} ${text}`
+    return stars === 1 ? `**${text}**` : `${HEADING_LEVELS[stars as 2 | 3 | 4] ?? "#"} ${text}`
   }
   if ((m = line.match(INTERNAL_RE)) && !m[1].startsWith("http")) {
-    return `**${m[1]}**`
+    const content = m[1]
+    if (content.length > 0 && !/^\s/.test(content) && content.trim().length > 0) {
+      return `**${content}**`
+    }
   }
   return line
 }

--- a/docs/superpowers/plans/2026-05-04-cosense-sync-phase-1.md
+++ b/docs/superpowers/plans/2026-05-04-cosense-sync-phase-1.md
@@ -1103,6 +1103,12 @@ test("deletePost removes the directory", async () => {
   expect(() => statSync(join(root, post.id))).toThrow()
   expect(readFileSync(join(root, "to-delete.md"), "utf8")).toBe("x")
 })
+
+test("does not leave a .tmp file when write succeeds", async () => {
+  await writePost(post, root)
+  const dest = join(root, post.id, "index.md")
+  expect(() => statSync(`${dest}.tmp`)).toThrow()
+})
 ```
 
 Run: `pnpm test:unit lib/sync/fs-writer.test.ts` → red.
@@ -1112,7 +1118,7 @@ Run: `pnpm test:unit lib/sync/fs-writer.test.ts` → red.
 ```ts
 // lib/sync/fs-writer.ts
 import { existsSync } from "node:fs"
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { mkdir, readFile, rename, rm, unlink, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { emitFrontmatter } from "./frontmatter"
 import type { Post } from "./types"
@@ -1132,23 +1138,29 @@ export async function writePost(post: Post, postsRoot: string): Promise<void> {
     const cur = await readFile(dest, "utf8")
     if (cur === next) return
   }
-  await writeFile(dest, next)
+  const tmp = `${dest}.tmp`
+  await writeFile(tmp, next)
+  try {
+    await rename(tmp, dest)
+  } catch (err) {
+    await unlink(tmp).catch(() => {})
+    throw err
+  }
 }
 
 export async function deletePost(id: string, postsRoot: string): Promise<void> {
   const dir = join(postsRoot, id)
-  if (!existsSync(dir)) return
   await rm(dir, { recursive: true, force: true })
 }
 ```
 
-Run: `pnpm test:unit lib/sync/fs-writer.test.ts` → green.
+Run: `pnpm test:unit lib/sync/fs-writer.test.ts` → green (5/5 tests).
 
 - [ ] **Step 3: Commit**
 
 ```bash
 git add lib/sync/fs-writer.ts lib/sync/fs-writer.test.ts
-git commit -m "Add idempotent post writer + deletePost"
+git commit -m "fs-writer: atomic write via tmp + rename, drop redundant existsSync in deletePost"
 ```
 
 ---

--- a/docs/superpowers/plans/2026-05-04-cosense-sync-phase-1.md
+++ b/docs/superpowers/plans/2026-05-04-cosense-sync-phase-1.md
@@ -1693,7 +1693,7 @@ test("aborts when deletes exceed ratio", async () => {
 - [ ] **Step 3: Run, then fix any small refactor issues**
 
 Run: `pnpm test:unit scripts/sync-cosense.test.ts`
-Expected: green. If a test fails because the orchestrator imports `gray-matter` (already a project dep, see `package.json`), that's expected to work — it's used elsewhere in the build.
+Expected: green. The orchestrator parses the `updated_at:` line with a regex (see `UPDATED_AT_RE` and the comment above it in `scripts/sync-cosense.ts`); `gray-matter@4` is unusable because of the project's `js-yaml@4` overrides.
 
 - [ ] **Step 4: Commit**
 
@@ -1816,7 +1816,7 @@ Verify in the GitHub Actions UI that "Sync from Cosense" appears under workflows
 
 ## Self-review notes (for the implementer)
 
-- The orchestrator imports `gray-matter` — that's an existing dep used by Velite's content layer, so it's safe to use.
+- The orchestrator parses the `updated_at:` line with a regex (see `UPDATED_AT_RE` and the comment above it in `scripts/sync-cosense.ts`); `gray-matter@4` is unusable because of the project's `js-yaml@4` overrides.
 - `import.meta.url === \`file://${process.argv[1]}\`` is the standard "is this script run directly under tsx?" idiom; if it doesn't trigger when run via `pnpm sync`, fall back to gating with `process.env.NODE_ENV !== "test"` and call `runSync(...)` from the script body unconditionally outside tests.
 - The integration test in Task 13 stubs the client object directly rather than spawning a subprocess. Do not be tempted to spawn `tsx scripts/sync-cosense.ts` — it adds 2-3 s per test for no signal gain.
 - If the Scrapbox notation table grows past ~15 rows, split the table tests into thematic `describe` blocks but keep the data-driven structure.

--- a/docs/superpowers/plans/2026-05-04-cosense-sync-phase-1.md
+++ b/docs/superpowers/plans/2026-05-04-cosense-sync-phase-1.md
@@ -81,6 +81,7 @@ Then edit `package.json` `scripts` block — add two entries, leave `test` (= ts
 - [ ] **Step 2: Create `vitest.config.ts`**
 
 ```ts
+import { fileURLToPath } from "node:url"
 import { defineConfig } from "vitest/config"
 
 export default defineConfig({
@@ -91,7 +92,9 @@ export default defineConfig({
     pool: "forks",
   },
   resolve: {
-    alias: { "@": new URL(".", import.meta.url).pathname.replace(/\/$/, "") },
+    alias: {
+      "@": fileURLToPath(new URL(".", import.meta.url)).replace(/[\\/]$/, ""),
+    },
   },
 })
 ```

--- a/docs/superpowers/plans/2026-05-04-cosense-sync-phase-1.md
+++ b/docs/superpowers/plans/2026-05-04-cosense-sync-phase-1.md
@@ -399,7 +399,7 @@ test("emits keys in a stable order", () => {
   expect(emitFrontmatter(post)).toBe(
     [
       "---",
-      "title: Sample Post",
+      "title: 'Sample Post'",
       "created_at: '2026-05-01T00:00:00.000Z'",
       "updated_at: '2026-05-04T12:34:56.000Z'",
       "path: /0123456789abcdef01234567",
@@ -422,6 +422,18 @@ test("escapes single quotes in title", () => {
   const out = emitFrontmatter({ ...post, title: "Don't break" })
   expect(out).toContain("title: \"Don't break\"")
 })
+
+test("rejects scalars with embedded newlines", () => {
+  expect(() =>
+    emitFrontmatter({ ...post, description: "first\nsecond" }),
+  ).toThrow(/newline/)
+})
+
+test("escapes backslash before quote in mixed-quote case", () => {
+  const out = emitFrontmatter({ ...post, title: "It's \\n literal" })
+  // Title quoted with double quotes; backslash doubled, then \n preserved.
+  expect(out).toContain(`title: "It's \\\\n literal"`)
+})
 ```
 
 - [ ] **Step 2: Run, confirm red**
@@ -432,29 +444,29 @@ Expected: FAIL with module-not-found.
 - [ ] **Step 3: Implement the emitter**
 
 ```ts
-// lib/sync/frontmatter.ts
 import type { Post } from "./types"
 
-function quoteIfNeeded(s: string): string {
-  // YAML: single-quote strings unless they themselves contain single quotes.
-  if (s.includes("'")) return `"${s.replace(/"/g, '\\"')}"`
+function quoteScalar(s: string): string {
+  if (/[\n\r]/.test(s)) {
+    throw new Error(`frontmatter scalar must not contain newlines: ${JSON.stringify(s)}`)
+  }
+  // YAML: single-quote unless the value itself contains a single quote.
+  // In that case use double quotes and escape backslashes (first) and
+  // double quotes (second). Order matters — if we escaped " before \,
+  // the inserted backslashes would get doubled too.
+  if (s.includes("'")) {
+    return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`
+  }
   return `'${s}'`
-}
-
-function plainOrQuoted(s: string): string {
-  // Strings that look "safe" (no special chars, no leading whitespace) can
-  // go unquoted. Frontmatter consumers (gray-matter via Velite) accept both.
-  if (/^[A-Za-z0-9 _.-]+$/.test(s) && s.trim() === s) return s
-  return quoteIfNeeded(s)
 }
 
 export function emitFrontmatter(post: Post): string {
   const lines: string[] = ["---"]
-  lines.push(`title: ${plainOrQuoted(post.title)}`)
+  lines.push(`title: ${quoteScalar(post.title)}`)
   lines.push(`created_at: '${post.createdAt.toISOString()}'`)
   lines.push(`updated_at: '${post.updatedAt.toISOString()}'`)
   lines.push(`path: /${post.id}`)
-  lines.push(`description: ${quoteIfNeeded(post.description)}`)
+  lines.push(`description: ${quoteScalar(post.description)}`)
   if (post.tags.length > 0) {
     lines.push("tags:")
     for (const tag of post.tags) lines.push(`  - ${tag}`)
@@ -467,7 +479,7 @@ export function emitFrontmatter(post: Post): string {
 - [ ] **Step 4: Run, confirm green**
 
 Run: `pnpm test:unit lib/sync/frontmatter.test.ts`
-Expected: all 3 tests pass.
+Expected: all 5 tests pass.
 
 - [ ] **Step 5: Commit**
 

--- a/docs/superpowers/specs/2026-05-04-cosense-phase-2-design.md
+++ b/docs/superpowers/specs/2026-05-04-cosense-phase-2-design.md
@@ -1,0 +1,420 @@
+# 2026-05-04: Cosense sync — Phase 2 (publish-from-Cosense)
+
+## Context
+
+Phase 1 (PR #702) shipped a working Cosense → blog sync engine but its
+sync model — "every Cosense page becomes a blog post under
+`/<page-id>/`" — is incompatible with the actual repo state discovered
+during Phase 1 acceptance:
+
+- The Cosense project `jaxx2104` has **51 pages**.
+- The blog has **109 posts** under `content/posts/`.
+- **48 of the 51 Cosense pages already exist as blog posts** (title-identical, manually copied over the years — the oldest match dates to 2019).
+- **3 Cosense pages are not yet on the blog** (`Antigravity`, `clay`, `kashitaka`); the author plans to publish them too.
+- **61 blog posts have no Cosense counterpart** (older PHP / Mac / Titanium / etc. content the author has not touched in years).
+
+Cosense is therefore not a single source of truth — it is a wiki / draft
+space, parts of which the author has chosen to publish on the blog.
+Phase 1's published interpretation ("everything in Cosense becomes a
+blog post at `/<page-id>/`") would, if run today, create 48 duplicate
+URLs and silently publish 3 pages the author may not be ready to
+publish.
+
+This spec replaces Phase 1's notion of source-of-truth migration with a
+narrower, safer model: **a blog post stub is the publishing decision;
+Cosense provides the content**.
+
+## Mental model
+
+| Role | Owner | Lifecycle |
+|------|-------|-----------|
+| **Publishing decision** (URL, slug, OGP, "this is on the blog") | Blog post directory under `content/posts/<slug>/index.md` | Created by hand (or by the optional helper in §Optional helpers) |
+| **Body text + future edits** | Cosense page (matched by title) | Edited from any device |
+| **Build + deploy** | Velite + TanStack Start + Cloudflare Pages | Unchanged from Phase 1 |
+| **Blog-only posts** (61) | Blog md only | Untouched by sync |
+| **Cosense-only pages** (drafts, wiki notes) | Cosense only | Never published unless a blog stub appears |
+
+The author's "どこからでも書きたい" requirement is met: writing happens
+in Cosense (web / iOS / Android), and edits flow to whichever blog
+posts have a matching stub. New articles require one one-time gesture
+(create the blog stub) to opt in.
+
+## Goals
+
+1. Cosense edits to a page that has a matching blog post propagate to
+   that post's `index.md` within one cron interval, with no manual
+   git work on the author's part.
+2. Cosense pages that **do not** match any blog post are never
+   auto-published. Drafts stay drafts.
+3. Existing blog post URLs (109 of them) remain canonical and
+   unchanged. No `/<page-id>/` URLs are introduced.
+4. Adding a new article from Cosense requires exactly one manual
+   gesture: create a stub `content/posts/<slug>/index.md` with the
+   matching `title:` field. Sync fills in the body on the next run.
+5. Phase 1's per-task safety properties (atomic writes, schema
+   validation at the API boundary, idempotency) are preserved or
+   strengthened.
+
+## Non-goals
+
+1. Importing the 61 blog-only posts into Cosense. They are valid as-is.
+2. Deleting blog posts when the matching Cosense page is deleted.
+   Cosense and blog deletion lifecycles are explicitly **decoupled**.
+3. A bidirectional sync (blog → Cosense). Edits made directly to
+   `index.md` are eventually overwritten by the next sync if the
+   matching Cosense page changes.
+4. Automatic title-rename handling on the blog side. If a user renames
+   a Cosense page, sync uses the recorded `cosense_id` to keep the
+   pairing — but does not move the blog post's directory.
+5. Migration scripts to push existing blog md into Cosense.
+
+## Architecture
+
+```
+                       ┌────────────────────────────────────────┐
+   ✍️  any device   →  │  Cosense project (jaxx2104)            │  wiki / drafts / source
+                       │  - 51 pages today                      │
+                       │  - 48 of them have blog stubs          │
+                       │  - 3 are drafts pending stubs          │
+                       └────────────────────────────────────────┘
+                                          │   HTTPS GET /api/pages/...
+                                          ▼
+                       ┌────────────────────────────────────────┐
+   ⏰ cron (30 min)  → │  .github/workflows/sync.yml            │
+                       │   └─ pnpm sync                          │
+                       │       └─ scripts/sync-cosense.ts       │
+                       │           ├─ fetch pages list           │
+                       │           ├─ load blog post stubs       │
+                       │           │    (title -> dir map)       │
+                       │           ├─ for each Cosense page:     │
+                       │           │   if stub matches: update   │
+                       │           │   else: skip (draft)        │
+                       │           ├─ download images             │
+                       │           └─ commit + push if dirty     │
+                       └────────────────────────────────────────┘
+                                          │
+                                          ▼
+                       ┌────────────────────────────────────────┐
+                       │  GitHub repo: content/posts/<slug>/    │
+                       │   ├─ index.md   (existing, body refreshed) │
+                       │   └─ *.png/jpg  (downloaded images)    │
+                       │  No public/_redirects changes.         │
+                       └────────────────────────────────────────┘
+                                          │   Cloudflare Pages build
+                                          ▼
+                       Existing build pipeline, unchanged.
+```
+
+The directory structure under `content/posts/` is **untouched** by
+Phase 2 — same date-prefix slugs, same URLs, same Velite output.
+
+## Components — what changes from Phase 1
+
+Phase 1's modules are reused as-is, with two surgical changes:
+
+| Module | Change |
+|--------|--------|
+| `lib/sync/types.ts` | Add a new IR field `Post.blogDir: string` (the existing post directory name, used as the write target). Add `LocalPostState.title` and `LocalPostState.cosenseId?: string` so `diff.ts` can resolve matches. |
+| `lib/sync/diff.ts` | Replace page-id-based diff with **title-then-id matching**: build a `Map<normalizedTitle, LocalPostState>`; for each Cosense page, find a stub by title; classify as `update` (if matched) or `skip` (if no stub). Drop the `delete` action — Cosense and blog lifecycles are decoupled. |
+| `lib/sync/fs-writer.ts` | Write into `content/posts/<existing-dir>/index.md`, not `content/posts/<page-id>/`. Preserve the existing frontmatter's `path:`, `category:`, `tags:`, `created_at:`. Update `updated_at:` from Cosense. Replace body. Stamp a new `cosense_id:` field for stable pairing on next runs. |
+| `lib/sync/transform.ts` | Stop deriving `path: /<page-id>`. The blog stub already has `path:`. The transform output now omits `path:`. |
+| `lib/sync/redirects.ts` | **Removed**. No `_redirects` are generated by Phase 2 — there are no URL changes to redirect. The seed file `redirects-seed.json` from Phase 1's plan is never created. |
+| `lib/sync/cosense-client.ts` | Implement `skip`-loop pagination (Phase 1 only asserted; Phase 2 must actually loop). |
+| `scripts/sync-cosense.ts` | Per-page error tolerance: a single page failure writes to `.sync-errors.json` and continues; the workflow surfaces the count as an annotation but does not fail the run. Drop the `MAX_DELETE_RATIO` env (no deletes). |
+
+## Slug strategy
+
+There is no slug derivation in Phase 2. The blog stub's directory name
+**is** the canonical location. Cosense's `id` is recorded as
+`cosense_id:` in frontmatter, used only for stable pairing across
+title renames.
+
+If the author renames a Cosense page, the sync script:
+1. Looks up by `cosense_id` first (stable — survives title rename).
+2. If not found, falls back to title match.
+3. If still not found, treats the page as a draft (no action).
+
+## Frontmatter mapping
+
+Sync writes only these fields, leaving everything else in the existing
+frontmatter alone:
+
+| Field | Source | Behaviour |
+|-------|--------|-----------|
+| `cosense_id` | Cosense `id` | Stamped on first match; preserved thereafter |
+| `updated_at` | Cosense `updated` (ISO 8601) | Overwritten each sync if newer |
+| `body` (the markdown after `---`) | `transformPage(page).body` | Overwritten each sync |
+
+Untouched (preserved verbatim from the existing stub):
+
+- `title`
+- `created_at`
+- `path`
+- `description`
+- `category`
+- `tags`
+
+Rationale: the author's existing posts have curated descriptions,
+categories, and tags that should not be clobbered by automated
+extraction. Cosense's hashtag-derived tags would silently overwrite
+the author's choices.
+
+## Title matching
+
+Title comparison uses **trimmed exact match** (Cosense titles already
+exclude leading/trailing whitespace; YAML frontmatter parsing strips
+quotes). Strings are compared after `.normalize("NFC")` on both sides —
+Cosense and macOS file systems can disagree on Unicode normalization
+form for combining characters (the existing 109 posts were authored on
+macOS over many years). No case-folding, no fuzzy matching — keeping
+the contract trivial avoids accidentally pairing wrong posts.
+
+If two blog stubs have the same title (which would be a user error in
+the existing 109), sync aborts the whole run with a clear error
+listing the conflicting paths.
+
+## Data flow
+
+1. **Trigger** — GitHub Actions cron (`*/30 * * * *`) or local
+   `pnpm sync`.
+2. **Fetch list** — paginated `GET /api/pages/<project>?limit=1000&skip=N`
+   until the entire project is enumerated.
+3. **Read local state** — for every `content/posts/*/index.md`:
+   parse the frontmatter (regex-based, see Phase 1's `UPDATED_AT_RE`
+   workaround), extract `title`, optional `cosense_id`, and
+   `updated_at`. Build two maps: `byTitle` and `byId`.
+4. **Pair** — for each Cosense page:
+   - Try `byId.get(page.id)` first.
+   - Fall back to `byTitle.get(page.title.trim())`.
+   - On hit: enqueue an `update` action targeting the stub's
+     directory.
+   - On miss: enqueue a `skip` action with the page title (logged for
+     operator awareness).
+5. **Skip-or-update** — for each `update` action, compare Cosense
+   `updated` (epoch seconds) to the stub's `updated_at` ISO timestamp.
+   If equal or older, mark `unchanged` and skip the network round-trip.
+6. **Per-page work** — for each remaining `update`:
+   - `getPage(title)` → IR via `transformPage`.
+   - Download images into the existing post directory (atomic write
+     pattern from Phase 1).
+   - Render new frontmatter by merging existing fields with the
+     three sync-managed fields (`cosense_id`, `updated_at`, body).
+   - Atomic write `index.md`.
+   - On any per-page exception: log to `.sync-errors.json` with
+     `{ title, error: msg }` and continue.
+7. **Commit & push** — workflow only, not the script. Skipped if
+   `git status --porcelain` is empty.
+
+The script writes a one-line summary on stdout:
+```
+plan: 5 update, 2 unchanged, 3 skip(no-stub), 0 errors
+```
+
+## Deletion semantics
+
+**Decoupled.** Cosense and blog deletions are independent:
+
+- A page deleted in Cosense → the corresponding blog post is **left
+  alone** on the blog. Sync simply stops finding the match. The post
+  continues to render from its existing md.
+- A blog post deleted by hand (the author runs `git rm -r
+  content/posts/<dir>`) → next sync ignores the corresponding Cosense
+  page (no stub = draft). The Cosense page is unaffected.
+
+This eliminates Phase 1's `MAX_DELETE_RATIO` safety check (no longer
+applicable) and the entire "delete" code path in `diff.ts` and the
+orchestrator. Simplification, not feature loss — Phase 1's deletion
+semantics were a forced consequence of the source-of-truth model that
+this spec rejects.
+
+## Optional helpers
+
+Not required for Phase 2 acceptance, but each is worth ~30 LOC and
+removes a manual step:
+
+- **`pnpm blog:promote "Cosense Page Title"`** — generates a stub
+  `content/posts/<YYYY-MM-DD-slug>/index.md` with `title:` and
+  `created_at:` populated, the rest blank. The author edits `path:`
+  and `description:` once, commits, and the next sync fills in the
+  body.
+- **`pnpm sync:report`** — runs a dry-run and prints the unmatched
+  Cosense pages (drafts) so the author can see what's pending
+  promotion.
+
+These ship in a follow-up PR if appetite remains after the core spec
+lands.
+
+## Error handling
+
+Tightened from Phase 1's "abort on first failure" to a per-page
+tolerance pattern, since cron is enabled in this phase and a single
+broken page must not block all subsequent syncs.
+
+| Failure | Behaviour |
+|---------|-----------|
+| Cosense API 5xx / timeout on `listPages` | Abort whole sync; non-zero exit |
+| Cosense API 5xx on a single `getPage` | Skip that page; record `{title, error}` to `.sync-errors.json`; continue |
+| Image download failure | Skip the entire page (no half-broken md); record |
+| Frontmatter parse failure on a stub | Skip; record `{path, error}`; continue |
+| Duplicate stub title | Abort whole sync; print conflicting paths |
+| `cosense_id` of a Cosense page collides with another stub's `cosense_id` | Abort whole sync (impossible without manual edit; bail loudly) |
+| `COSENSE_PROJECT` / `COSENSE_SID` missing | Exit non-zero on script start |
+
+The workflow surfaces `.sync-errors.json` as a GitHub Actions warning
+annotation summary and uploads it as an artifact. The run does not
+fail on per-page errors.
+
+For the author's specific Cosense project (which is public),
+`COSENSE_SID` may be a placeholder string. The script does not validate
+the cookie value beyond non-empty. A separate spec change can later
+make `COSENSE_SID` optional, but it is not in scope here.
+
+## Test strategy
+
+Phase 1's vitest suite mostly carries over. Net changes:
+
+- **`lib/sync/diff.test.ts`** — rewrite for title-then-id matching,
+  covering: title match, id match (after rename), no match (draft),
+  duplicate-title abort.
+- **`lib/sync/fs-writer.test.ts`** — add: preserves existing
+  frontmatter, stamps `cosense_id` on first match, overwrites body
+  only.
+- **`scripts/sync-cosense.test.ts`** — integration test now uses
+  fixtures with stub directories pre-populated, verifies updates land
+  in the existing dirs (not new `<page-id>/` dirs), verifies skip
+  count for unmatched pages, verifies idempotency.
+- **New: `lib/sync/cosense-client.test.ts`** — pagination loop test
+  (multiple `skip` calls).
+
+Existing build (`pnpm test`, `pnpm build`) remains the final
+acceptance gate.
+
+## GitHub Actions workflow shape
+
+`.github/workflows/sync.yml` (changes from Phase 1):
+
+```yaml
+on:
+  schedule:
+    - cron: "*/30 * * * *"      # NEW in Phase 2
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        type: boolean
+        default: false
+
+jobs:
+  sync:
+    # ... same as Phase 1 ...
+    steps:
+      # ... checkout, pnpm setup, install ...
+      - run: pnpm sync ${{ inputs.dry_run && '--dry-run' || '' }}
+        env:
+          COSENSE_PROJECT: ${{ secrets.COSENSE_PROJECT }}
+          COSENSE_SID:     ${{ secrets.COSENSE_SID }}
+      - name: commit & push
+        if: ! inputs.dry_run
+        run: |
+          if [ -n "$(git status --porcelain content)" ]; then
+            git config user.name  "blog-sync[bot]"
+            git config user.email "blog-sync@users.noreply.github.com"
+            git add content
+            git commit -m "sync: pull from Cosense"
+            git push origin main
+          fi
+      - name: surface skipped/errored pages
+        if: always() && hashFiles('.sync-errors.json') != ''
+        run: |
+          jq . .sync-errors.json >> $GITHUB_STEP_SUMMARY
+      - name: upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sync-output
+          path: |
+            .sync-plan.json
+            .sync-errors.json
+          if-no-files-found: ignore
+```
+
+Note `git add content` (not `content public`) — Phase 2 never touches
+`public/`.
+
+## Configuration surface
+
+| Var | Required | Default | Purpose |
+|-----|----------|---------|---------|
+| `COSENSE_PROJECT` | yes | — | Cosense project name |
+| `COSENSE_SID` | yes | — | Cosense session cookie (placeholder OK for public projects) |
+| `SYNC_DRY_RUN` | no | `false` | Equivalent to `--dry-run` |
+
+`MAX_DELETE_RATIO` from Phase 1 is removed.
+
+## Phasing within Phase 2
+
+This spec ships in **one PR** (Phase 2 is small enough — most code is
+diff/transform tweaks rather than new modules). Suggested commit order
+for the implementation plan:
+
+1. Pagination loop in `cosense-client.ts` (with test) — independent.
+2. Refactor `diff.ts` to title-then-id matching (with rewritten tests).
+3. Refactor `fs-writer.ts` to merge-into-existing-stub semantics.
+4. Drop `redirects.ts`, `redirects-seed.json` references; simplify
+   orchestrator.
+5. Per-page error tolerance + `.sync-errors.json`.
+6. Workflow update: enable cron, drop `MAX_DELETE_RATIO`, add
+   artifact upload.
+7. Acceptance: `gh workflow run sync.yml --field dry_run=true`,
+   inspect `.sync-errors.json` (expect 3 entries — `Antigravity`,
+   `clay`, `kashitaka` — matching the known drafts pending
+   stub creation).
+
+## Acceptance criteria
+
+1. After Phase 2 ships, a `dry_run: true` invocation against the
+   current Cosense project produces a plan with **0 create, 48 update
+   (or unchanged), 0 delete, 3 skip(no-stub)** — proving the new
+   matching model works end-to-end.
+2. Editing a Cosense page that has a matching blog post results in
+   the change appearing on the blog within one cron interval. The
+   blog post's URL does not change.
+3. Deleting a Cosense page does not remove the blog post.
+4. The author creating a blog stub for `Antigravity` (with a date
+   slug, `title: Antigravity`, no body) and waiting one cron interval
+   results in the body being filled from Cosense.
+5. `pnpm test`, `pnpm test:unit`, `pnpm lint:ci`, and `pnpm build`
+   all pass on the Phase 2 PR.
+
+## Open questions
+
+None at design time. The following are deliberately deferred:
+
+- **`pnpm blog:promote` helper script.** Optional; ships in a
+  follow-up PR if the manual stub-creation friction proves annoying.
+- **`COSENSE_SID` made optional for public projects.** Cosmetic;
+  current placeholder workaround is acceptable.
+- **Bidirectional sync (blog → Cosense).** Out of scope. The author's
+  workflow is one-way (write in Cosense, publish via stub).
+- **Backfill of the 61 blog-only posts to Cosense.** Out of scope.
+  These posts will continue to be edited via direct git operations
+  if the author chooses to update them at all.
+
+## Changes from Phase 1's spec
+
+For reviewers comparing against `2026-05-04-cosense-source-of-truth-design.md`:
+
+- **Source-of-truth claim removed.** Cosense is no longer the single
+  source of truth; it is the authoring surface for posts that have
+  opted into publishing via a blog stub.
+- **`/<page-id>/` URLs removed.** All publishing happens at the
+  existing blog post URLs.
+- **Migration step removed.** No bulk import of blog md into Cosense.
+- **`public/_redirects` generation removed.** Phase 2 never writes to
+  `public/`.
+- **Mirror deletion removed.** Cosense delete no longer cascades to
+  the blog.
+- **`MAX_DELETE_RATIO` removed.** No deletions to guard.
+- **Per-page error tolerance promoted from "deferred" to "required"**
+  because cron is enabled this phase.
+- **Pagination loop required**, not just asserted (Phase 1 had an
+  assertion-only stub).

--- a/docs/superpowers/specs/2026-05-04-cosense-source-of-truth-design.md
+++ b/docs/superpowers/specs/2026-05-04-cosense-source-of-truth-design.md
@@ -1,0 +1,391 @@
+# 2026-05-04: Cosense as source of truth for blog posts
+
+## Context
+
+Posts are currently authored as Markdown files under `content/posts/<slug>/index.md`,
+edited locally, and committed directly to the repository. The 109 posts on
+`main` (oldest from 2013-08-06, newest from 2025-12-15) all follow this
+flow. The Velite content layer reads these files at build time and emits
+`.velite/` JSON consumed by TanStack Start during prerender.
+
+The author has identified one primary pain point with this flow:
+**writing must happen on a machine with the local editor and a working
+git checkout**. Phone, tablet, and borrowed laptops are out. Among the
+candidate replacement tools (Notion, Cosense/Scrapbox, Obsidian),
+**Cosense** is the chosen primary source.
+
+This spec defines a one-way, sync-time fetch pipeline that makes a
+Cosense project the single source of truth for blog content while
+preserving the existing Velite + TanStack Start + Cloudflare Pages
+build pipeline unchanged.
+
+Out of scope for this spec:
+
+- Multi-source ingestion (Notion, Obsidian). The internal IR is shaped
+  to allow future adapters, but no second adapter is built here.
+- Bidirectional sync (Cosense ↔ md). Edits made by hand in `content/posts/`
+  are overwritten by the next sync.
+- A built-in browser CMS hosted on the blog itself.
+- Real-time collaboration features beyond what Cosense already provides.
+- Image optimization beyond what Velite already does.
+
+## Goals
+
+1. The author can write or edit a post on any device that runs Cosense
+   (web, iOS, Android) and have it published to the blog without
+   touching a git client.
+2. The existing build pipeline (`pnpm build` = `velite build` + `vite
+   build` + Cloudflare Pages) is **not modified**. The only thing that
+   changes is the source of `content/posts/<id>/index.md`.
+3. Existing URLs continue to resolve via redirects after the one-time
+   migration. No old link 404s.
+4. A Cosense API outage cannot break a Cloudflare Pages build.
+
+## Non-goals
+
+1. Preserving the exact existing URL slugs as canonical. Old URLs are
+   redirected to new ones; they are not the new canonical form.
+2. Avoiding overwrite of hand-edited Markdown. Sync is one-way and
+   destructive on the repository side by design.
+3. Supporting a publishing-flag workflow inside a shared Cosense
+   project. This design assumes the Cosense project is dedicated to
+   the blog (every page = one article).
+
+## Architecture
+
+```
+                       ┌────────────────────────────────────────┐
+   ✍️  any device   →  │  Cosense project (jaxx-blog)           │  source of truth
+                       │  - 1 page = 1 article                  │
+                       │  - images on Gyazo / scrapbox.io/files │
+                       └────────────────────────────────────────┘
+                                          │   HTTPS GET /api/pages/...
+                                          ▼
+                       ┌────────────────────────────────────────┐
+   ⏰ cron (30 min)  → │  .github/workflows/sync.yml            │
+                       │   └─ pnpm sync                          │
+                       │       └─ scripts/sync-cosense.ts       │
+                       │           ├─ fetch pages list           │
+                       │           ├─ fetch each updated page    │
+                       │           ├─ transform → md+frontmatter │
+                       │           ├─ download images            │
+                       │           └─ git diff → commit + push   │
+                       └────────────────────────────────────────┘
+                                          │   git push origin main
+                                          ▼
+                       ┌────────────────────────────────────────┐
+                       │  GitHub repo: content/posts/<id>/      │
+                       │   ├─ index.md   (generated, tracked)   │
+                       │   └─ *.png/jpg  (downloaded)            │
+                       │  + public/_redirects (old → new URL)   │
+                       └────────────────────────────────────────┘
+                                          │   Cloudflare Pages build
+                                          ▼
+                       ┌────────────────────────────────────────┐
+                       │  Existing build (unchanged):            │
+                       │   pnpm build = velite + vite build      │
+                       │   → dist/client/ → Cloudflare Pages CDN │
+                       └────────────────────────────────────────┘
+```
+
+All new code is added under `scripts/`, `lib/sync/`, and
+`.github/workflows/`. No existing files in `app/`, `lib/` (outside
+`lib/sync/`), `styles/`, `components/`, `velite.config.ts`, or
+`vite.config.mts` are touched.
+
+## Components
+
+```
+scripts/
+  sync-cosense.ts            # orchestrator; the only CLI / GH Actions entry
+  migrate-md-to-cosense.ts   # one-shot, deleted after migration completes
+
+lib/sync/
+  types.ts                   # IR (intermediate representation); the only stable contract
+  cosense-client.ts          # Cosense API wrapper; fetch + zod-typed responses
+  transform.ts               # Cosense page → IR
+  scrapbox-to-md.ts          # Scrapbox notation → markdown string
+  frontmatter.ts             # IR → YAML frontmatter
+  slug.ts                    # Cosense page id → URL slug
+  images.ts                  # Gyazo / scrapbox.io image URL → local file
+  redirects.ts               # old slug → new slug map → public/_redirects body
+  redirects-seed.json        # frozen data file: old path → new page id (written by migration, read by sync)
+  fs-writer.ts               # idempotent writer for content/posts/<id>/
+```
+
+### Why this decomposition
+
+1. **`types.ts` is the only stable boundary.** Cosense client returns
+   IR; markdown emitter consumes IR. Adding a Notion adapter later
+   means writing `notion-client.ts` + `notion-transform.ts`; the rest
+   is reusable.
+2. **`scrapbox-to-md.ts` is a pure function.** This is the highest-bug
+   surface; isolating it as `(string) -> string` makes per-notation
+   table tests trivial.
+3. **`fs-writer.ts` is idempotent**: if the on-disk bytes match the
+   intended bytes, do not touch the file. This keeps `git diff` clean
+   on no-op runs.
+4. **`scripts/sync-cosense.ts` stays under ~100 lines.** It orchestrates
+   reads, transforms, and writes; it does not contain transform logic.
+
+## Slug strategy
+
+URLs are derived from the **Cosense page id** (the 24-char hex returned
+by the Cosense API), not from the page title.
+
+- New canonical URL: `/<page-id>/` (root-level, matching the existing
+  `app/routes/$.tsx` splat route convention; all 109 existing posts
+  already publish at `/<custom-path>/`, e.g. `/2025-purchases/`,
+  `/php-replace-lf/`, via the `path` frontmatter field).
+- Old URLs: redirected via `public/_redirects` (308) — see Migration.
+
+Rationale: page id is **immutable across title and body edits**. A
+title-derived slug would break URLs whenever the author renames a page,
+and a Japanese title cannot be percent-encoded into a readable URL
+anyway. The trade-off is an opaque URL; SEO is preserved through OGP
+`<title>` and the existing internal post-link UI which renders the
+human title.
+
+## Frontmatter mapping
+
+| Velite `postSchema` field | Source                                        |
+|---------------------------|-----------------------------------------------|
+| `title`                   | Cosense page title                            |
+| `created_at`              | Cosense page `created` (UNIX → ISO 8601)      |
+| `updated_at`              | Cosense page `updated` (UNIX → ISO 8601)      |
+| `path`                    | `/<page-id>`                                  |
+| `description`             | First non-empty body line, trimmed to 160ch   |
+| `category`                | Omitted (Cosense has no category equivalent)  |
+| `tags`                    | `#tag` syntax in body, plus inline `[tag]` links matching a small allowlist; both are optional |
+
+If `postSchema` validation fails after this mapping, the page is
+skipped (see Error handling).
+
+## Data flow
+
+1. **Trigger** — GitHub Actions cron (`*/30 * * * *`) or local
+   `pnpm sync`.
+2. **Read local state** — enumerate `content/posts/*/index.md`. Each
+   directory name is a Cosense page id; each frontmatter `updated_at`
+   is the watermark.
+3. **Fetch list** — `GET /api/pages/<project>?limit=1000` returns
+   `(id, title, updated)` for every page. Pagination via `skip` if the
+   project exceeds the limit.
+4. **Diff** — for each remote page, compare `updated` to local
+   frontmatter `updated_at`. Classify as **new**, **updated**,
+   **unchanged**, or (for local-only entries) **deleted**.
+5. **Per-page work** — for new and updated pages: fetch full body, run
+   transform, download referenced images into the post directory, and
+   write `index.md` via `fs-writer.ts`. For deleted pages: remove the
+   directory.
+6. **Rebuild `_redirects`** — regenerate `public/_redirects` from the
+   full set of (old slug → new id) mappings retained from the
+   migration step (see below).
+7. **Commit & push** — handled by the workflow, not the script. If
+   `git status --porcelain` is empty after step 6, the workflow exits
+   without committing.
+
+State is stored exclusively in the repository itself (no
+`.sync-state.json`). The combination of `content/posts/<id>/` directory
+existence and frontmatter `updated_at` is sufficient to compute every
+diff.
+
+## Deletion semantics
+
+Cosense is a perfect mirror. A page deleted in Cosense is deleted from
+the blog on the next sync. This includes the post directory (Markdown
++ images). Recovery is via `git revert` on the sync commit.
+
+**Safety net:** if the sync run would delete more than 50% of the
+existing post directories, the script aborts before writing anything.
+The threshold is `MAX_DELETE_RATIO` and overridable via env var. This
+guards against a transient empty Cosense API response wiping the
+archive.
+
+## Migration: 109 existing md → Cosense
+
+A one-shot script `scripts/migrate-md-to-cosense.ts` does the following
+for each existing post:
+
+1. Read the existing `content/posts/<old-dir>/index.md`.
+2. Capture `frontmatter.path` (e.g. `/2025-purchases`) — this is the
+   live URL today and must be kept resolvable post-migration.
+3. Convert markdown body → Scrapbox notation (the inverse of the
+   sync-time transform; same module, applied in reverse).
+4. Upload to the target Cosense project via the page-create API.
+5. Record the resulting Cosense page id.
+6. Append `{ "old_path": "/2025-purchases", "new_id": "<page-id>" }`
+   to `lib/sync/redirects-seed.json`.
+
+After the migration:
+
+- The 109 `content/posts/<old-dir>/` directories are deleted from the
+  repository in the same migration PR.
+- `public/_redirects` is generated from `redirects-seed.json` for the
+  first time and committed.
+- Subsequent sync runs only have to maintain `_redirects` (re-emit it
+  from `redirects-seed.json` on every run); brand-new Cosense-native
+  pages do not need entries in `redirects-seed.json` because they
+  publish directly at `/<page-id>/` from day one.
+
+The migration script is idempotent on the Cosense side via the
+mapping file: rerunning skips entries already in `redirects-seed.json`.
+
+The migration runs on the author's machine, not in CI, since
+authoring a Cosense `COSENSE_SID` with write scope into GitHub
+secrets just for a one-shot script is unnecessary risk.
+
+## Error handling
+
+Asymmetric policy: **read failures are tolerant, write failures that
+could break the site are strict**.
+
+| Failure                            | Behaviour                                                                 |
+|------------------------------------|---------------------------------------------------------------------------|
+| Cosense API 5xx / timeout          | Abort whole sync, exit non-zero. Workflow marks the run failed; no commit |
+| Single page parse error            | Skip the page, continue, write entry to `.sync-errors.json`               |
+| Image download failure             | Skip the **entire page** (do not write a half-broken md)                  |
+| Velite `postSchema` rejects output | Skip the page (validation runs in `fs-writer.ts` before write)            |
+| Pending deletes exceed 50%         | Abort whole sync                                                          |
+| `_redirects` slug collision        | Abort whole sync (404 loop risk)                                          |
+| `COSENSE_PROJECT` / `COSENSE_SID` missing | Exit non-zero on script start, before any network call             |
+
+The workflow reads `.sync-errors.json` at the end of the run and
+attaches a GitHub Actions warning annotation summarizing skipped pages.
+The run does **not** fail on per-page errors; a follow-up cron run
+gets another chance to fetch the page after the author fixes it.
+
+## Test strategy
+
+Following `CLAUDE.md`'s "contracts strict, implementation regenerable":
+
+- **Unit (vitest)** for `lib/sync/`:
+  - `scrapbox-to-md.ts`: per-notation table tests (`[link]`, `[* bold]`,
+    code blocks, `table:`, image embeds, etc.). New notation discovered
+    in the wild starts as a red test before implementation (TDD).
+  - `frontmatter.ts`: round-trip IR ↔ YAML.
+  - `slug.ts` and `redirects.ts`: collision detection.
+- **Contract tests** for `cosense-client.ts`:
+  - `fixtures/cosense/*.json` are real API responses captured once.
+    Tests assert each fixture parses against the zod schema. Cosense
+    schema drift is detected the next time fixtures are refreshed.
+- **Integration test** for `scripts/sync-cosense.ts`:
+  - Stubbed Cosense client returns fixture data; script writes into a
+    temporary directory; output tree is compared against an expected
+    snapshot. Idempotency is verified by running the script twice and
+    asserting the second run is a no-op.
+- **Existing build** (`pnpm test` for tsc, `pnpm build` for velite +
+  vite) runs unchanged in CI as the final acceptance gate.
+- **Dry-run mode** — `pnpm sync --dry-run` writes a `.sync-plan.json`
+  describing the intended changes and exits without touching the
+  filesystem. Useful before flipping the cron on for the first time.
+
+CI additions: a new GitHub Actions step runs vitest. Existing
+`lint:ci` and `test` (tsc) continue unchanged.
+
+## GitHub Actions workflow shape
+
+`.github/workflows/sync.yml`:
+
+```yaml
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch: {}
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm sync
+        env:
+          COSENSE_PROJECT: ${{ secrets.COSENSE_PROJECT }}
+          COSENSE_SID:     ${{ secrets.COSENSE_SID }}
+      - name: commit & push
+        run: |
+          if [ -n "$(git status --porcelain content public)" ]; then
+            git config user.name  "blog-sync[bot]"
+            git config user.email "blog-sync@users.noreply.github.com"
+            git add content public
+            git commit -m "sync: pull from Cosense"
+            git push origin main
+          fi
+      - name: report skipped pages
+        if: always() && hashFiles('.sync-errors.json') != ''
+        run: cat .sync-errors.json | jq . >> $GITHUB_STEP_SUMMARY
+```
+
+`workflow_dispatch` is included so the author can trigger an immediate
+sync from the GitHub web UI ("どこからでも" requirement).
+
+## Configuration surface
+
+Environment variables (read by `scripts/sync-cosense.ts`):
+
+| Var                 | Required | Default | Purpose                                  |
+|---------------------|----------|---------|------------------------------------------|
+| `COSENSE_PROJECT`   | yes      | —       | Cosense project name (URL component)     |
+| `COSENSE_SID`       | yes      | —       | Cosense session cookie value             |
+| `MAX_DELETE_RATIO`  | no       | `0.5`   | Abort if deletes exceed this fraction    |
+| `SYNC_DRY_RUN`      | no       | `false` | Equivalent to `--dry-run` flag           |
+
+`COSENSE_SID` is required even for public Cosense projects because
+`/api/pages/<project>/<title>/text` returns the raw body only to
+authenticated requests in some project settings.
+
+## Phasing
+
+This spec is large enough that a single implementation plan would be
+unwieldy. Suggested split for the planning step:
+
+- **Phase 1 — Sync infrastructure.** `lib/sync/*` (excluding
+  `redirects-seed.json`), `scripts/sync-cosense.ts`,
+  `.github/workflows/sync.yml`, vitest setup, fixtures. Acceptance:
+  dry-run against a hand-populated test Cosense project produces the
+  expected plan.
+- **Phase 2 — Migration.** `scripts/migrate-md-to-cosense.ts`,
+  `lib/sync/redirects-seed.json`, the bulk deletion of
+  `content/posts/*/`, the first generated `public/_redirects`.
+  Acceptance: spot-check at least 5 random old URLs return 308 in
+  preview, and the first real sync run from the live cron is a no-op
+  (because the migration already wrote everything).
+
+The two phases ship as separate PRs. Phase 2 cannot land until Phase 1
+is on `main`, but it can be developed in parallel using the same
+`lib/sync/scrapbox-to-md.ts` module (used in reverse).
+
+## Open questions
+
+None at design time. The following will be decided during planning /
+implementation:
+
+- Exact Cosense project name (deferred to migration; the script accepts
+  it via env var).
+- Whether to keep `migrate-md-to-cosense.ts` in-tree after migration
+  (lean: delete in the migration PR; alternative: keep under
+  `scripts/archive/` for reference).
+
+## Acceptance criteria
+
+1. `pnpm sync --dry-run` against the populated Cosense project lists
+   the expected create/update/delete actions.
+2. After a real `pnpm sync`, `pnpm test` and `pnpm build` succeed
+   without modification.
+3. After the migration PR, every old URL of the form `/<old-path>/`
+   (sourced from each existing post's `frontmatter.path`) returns a
+   308 to its new `/<page-id>/` target on Cloudflare Pages.
+4. Editing a Cosense page from a phone results in the change appearing
+   on the blog within one cron interval.
+5. Deleting a Cosense page removes the corresponding post directory
+   from `main` within one cron interval.
+6. Triggering `gh workflow run sync.yml` performs an immediate sync
+   without waiting for the next cron tick.

--- a/lib/sync/__fixtures__/page-detail.json
+++ b/lib/sync/__fixtures__/page-detail.json
@@ -1,0 +1,11 @@
+{
+  "id": "0123456789abcdef01234567",
+  "title": "First Post",
+  "created": 1714521600,
+  "updated": 1714694400,
+  "lines": [
+    { "id": "l1", "text": "First Post",  "userId": "u1", "created": 1714521600, "updated": 1714521600 },
+    { "id": "l2", "text": "Intro line.", "userId": "u1", "created": 1714521600, "updated": 1714521600 },
+    { "id": "l3", "text": "[* highlight]","userId": "u1", "created": 1714521600, "updated": 1714521600 }
+  ]
+}

--- a/lib/sync/__fixtures__/page-detail.json
+++ b/lib/sync/__fixtures__/page-detail.json
@@ -4,8 +4,26 @@
   "created": 1714521600,
   "updated": 1714694400,
   "lines": [
-    { "id": "l1", "text": "First Post",  "userId": "u1", "created": 1714521600, "updated": 1714521600 },
-    { "id": "l2", "text": "Intro line.", "userId": "u1", "created": 1714521600, "updated": 1714521600 },
-    { "id": "l3", "text": "[* highlight]","userId": "u1", "created": 1714521600, "updated": 1714521600 }
+    {
+      "id": "l1",
+      "text": "First Post",
+      "userId": "u1",
+      "created": 1714521600,
+      "updated": 1714521600
+    },
+    {
+      "id": "l2",
+      "text": "Intro line.",
+      "userId": "u1",
+      "created": 1714521600,
+      "updated": 1714521600
+    },
+    {
+      "id": "l3",
+      "text": "[* highlight]",
+      "userId": "u1",
+      "created": 1714521600,
+      "updated": 1714521600
+    }
   ]
 }

--- a/lib/sync/__fixtures__/pages-list.json
+++ b/lib/sync/__fixtures__/pages-list.json
@@ -1,0 +1,17 @@
+{
+  "count": 2,
+  "pages": [
+    {
+      "id": "0123456789abcdef01234567",
+      "title": "First Post",
+      "created": 1714521600,
+      "updated": 1714694400
+    },
+    {
+      "id": "fedcba9876543210fedcba98",
+      "title": "Second Post",
+      "created": 1714521600,
+      "updated": 1714694400
+    }
+  ]
+}

--- a/lib/sync/cosense-client.test.ts
+++ b/lib/sync/cosense-client.test.ts
@@ -1,11 +1,8 @@
 import { readFileSync } from "node:fs"
 import { resolve } from "node:path"
 import { describe, expect, test, vi } from "vitest"
-import {
-  cosenseListResponseSchema,
-  cosensePageSchema,
-} from "./types"
 import { CosenseClient } from "./cosense-client"
+import { cosenseListResponseSchema, cosensePageSchema } from "./types"
 
 const listJson = JSON.parse(
   readFileSync(resolve(__dirname, "__fixtures__/pages-list.json"), "utf8"),
@@ -25,9 +22,11 @@ describe("schemas accept captured fixtures", () => {
 
 describe("CosenseClient", () => {
   test("listPages hits /api/pages/<project> and parses response", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify(listJson), { status: 200 }),
-    )
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify(listJson), { status: 200 }),
+      )
     const c = new CosenseClient({ project: "demo", sid: "s", fetch: fetchMock })
     const result = await c.listPages()
     expect(result.pages).toHaveLength(2)
@@ -40,9 +39,11 @@ describe("CosenseClient", () => {
   })
 
   test("getPage URL-encodes the title", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify(detailJson), { status: 200 }),
-    )
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify(detailJson), { status: 200 }),
+      )
     const c = new CosenseClient({ project: "demo", sid: "s", fetch: fetchMock })
     await c.getPage("Hello World")
     expect(fetchMock).toHaveBeenCalledWith(
@@ -52,16 +53,22 @@ describe("CosenseClient", () => {
   })
 
   test("non-2xx throws", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(new Response("x", { status: 503 }))
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response("x", { status: 503 }))
     const c = new CosenseClient({ project: "demo", sid: "s", fetch: fetchMock })
     await expect(c.listPages()).rejects.toThrow(/503/)
   })
 
   test("listPages aborts when count > pages.length (pagination needed)", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ count: 1500, pages: listJson.pages }), { status: 200 }),
+      new Response(JSON.stringify({ count: 1500, pages: listJson.pages }), {
+        status: 200,
+      }),
     )
     const c = new CosenseClient({ project: "demo", sid: "s", fetch: fetchMock })
-    await expect(c.listPages()).rejects.toThrow(/pagination is not yet implemented/)
+    await expect(c.listPages()).rejects.toThrow(
+      /pagination is not yet implemented/,
+    )
   })
 })

--- a/lib/sync/cosense-client.test.ts
+++ b/lib/sync/cosense-client.test.ts
@@ -56,4 +56,12 @@ describe("CosenseClient", () => {
     const c = new CosenseClient({ project: "demo", sid: "s", fetch: fetchMock })
     await expect(c.listPages()).rejects.toThrow(/503/)
   })
+
+  test("listPages aborts when count > pages.length (pagination needed)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ count: 1500, pages: listJson.pages }), { status: 200 }),
+    )
+    const c = new CosenseClient({ project: "demo", sid: "s", fetch: fetchMock })
+    await expect(c.listPages()).rejects.toThrow(/pagination is not yet implemented/)
+  })
 })

--- a/lib/sync/cosense-client.test.ts
+++ b/lib/sync/cosense-client.test.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { describe, expect, test, vi } from "vitest"
+import {
+  cosenseListResponseSchema,
+  cosensePageSchema,
+} from "./types"
+import { CosenseClient } from "./cosense-client"
+
+const listJson = JSON.parse(
+  readFileSync(resolve(__dirname, "__fixtures__/pages-list.json"), "utf8"),
+)
+const detailJson = JSON.parse(
+  readFileSync(resolve(__dirname, "__fixtures__/page-detail.json"), "utf8"),
+)
+
+describe("schemas accept captured fixtures", () => {
+  test("list response", () => {
+    expect(() => cosenseListResponseSchema.parse(listJson)).not.toThrow()
+  })
+  test("page detail", () => {
+    expect(() => cosensePageSchema.parse(detailJson)).not.toThrow()
+  })
+})
+
+describe("CosenseClient", () => {
+  test("listPages hits /api/pages/<project> and parses response", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(listJson), { status: 200 }),
+    )
+    const c = new CosenseClient({ project: "demo", sid: "s", fetch: fetchMock })
+    const result = await c.listPages()
+    expect(result.pages).toHaveLength(2)
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://scrapbox.io/api/pages/demo?limit=1000&skip=0",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Cookie: "connect.sid=s" }),
+      }),
+    )
+  })
+
+  test("getPage URL-encodes the title", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(detailJson), { status: 200 }),
+    )
+    const c = new CosenseClient({ project: "demo", sid: "s", fetch: fetchMock })
+    await c.getPage("Hello World")
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://scrapbox.io/api/pages/demo/Hello%20World",
+      expect.any(Object),
+    )
+  })
+
+  test("non-2xx throws", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("x", { status: 503 }))
+    const c = new CosenseClient({ project: "demo", sid: "s", fetch: fetchMock })
+    await expect(c.listPages()).rejects.toThrow(/503/)
+  })
+})

--- a/lib/sync/cosense-client.ts
+++ b/lib/sync/cosense-client.ts
@@ -31,7 +31,13 @@ export class CosenseClient {
     const url = `${BASE}/${encodeURIComponent(this.project)}?limit=1000&skip=0`
     const r = await this.fetcher(url, { headers: this.headers() })
     if (!r.ok) throw new Error(`Cosense list failed: ${r.status}`)
-    return cosenseListResponseSchema.parse(await r.json())
+    const parsed = cosenseListResponseSchema.parse(await r.json())
+    if (parsed.count > parsed.pages.length) {
+      throw new Error(
+        `Cosense project has ${parsed.count} pages but client only fetched ${parsed.pages.length}; pagination is not yet implemented`,
+      )
+    }
+    return parsed
   }
 
   async getPage(title: string): Promise<CosensePage> {

--- a/lib/sync/cosense-client.ts
+++ b/lib/sync/cosense-client.ts
@@ -1,0 +1,43 @@
+import {
+  type CosensePage,
+  cosenseListResponseSchema,
+  cosensePageSchema,
+} from "./types"
+
+export interface CosenseClientOptions {
+  project: string
+  sid: string
+  fetch?: typeof globalThis.fetch
+}
+
+const BASE = "https://scrapbox.io/api/pages"
+
+export class CosenseClient {
+  private readonly project: string
+  private readonly sid: string
+  private readonly fetcher: typeof globalThis.fetch
+
+  constructor(opts: CosenseClientOptions) {
+    this.project = opts.project
+    this.sid = opts.sid
+    this.fetcher = opts.fetch ?? globalThis.fetch
+  }
+
+  private headers(): HeadersInit {
+    return { Cookie: `connect.sid=${this.sid}` }
+  }
+
+  async listPages() {
+    const url = `${BASE}/${encodeURIComponent(this.project)}?limit=1000&skip=0`
+    const r = await this.fetcher(url, { headers: this.headers() })
+    if (!r.ok) throw new Error(`Cosense list failed: ${r.status}`)
+    return cosenseListResponseSchema.parse(await r.json())
+  }
+
+  async getPage(title: string): Promise<CosensePage> {
+    const url = `${BASE}/${encodeURIComponent(this.project)}/${encodeURIComponent(title)}`
+    const r = await this.fetcher(url, { headers: this.headers() })
+    if (!r.ok) throw new Error(`Cosense getPage failed: ${r.status}`)
+    return cosensePageSchema.parse(await r.json())
+  }
+}

--- a/lib/sync/diff.test.ts
+++ b/lib/sync/diff.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "vitest"
+import { computePlan, type LocalPostState } from "./diff"
+import type { CosenseListEntry } from "./types"
+
+const remote: CosenseListEntry[] = [
+  { id: "0123456789abcdef01234567", title: "A", updated: 1000 },
+  { id: "fedcba9876543210fedcba98", title: "B", updated: 2000 },
+]
+
+describe("computePlan", () => {
+  test("empty local -> all create", () => {
+    const plan = computePlan(remote, [])
+    expect(plan.actions.map((a) => a.kind).sort()).toEqual(["create", "create"])
+    expect(plan.localCount).toBe(0)
+  })
+
+  test("local matches remote with same updated -> unchanged", () => {
+    const local: LocalPostState[] = [
+      { id: "0123456789abcdef01234567", updatedAt: new Date(1000 * 1000) },
+      { id: "fedcba9876543210fedcba98", updatedAt: new Date(2000 * 1000) },
+    ]
+    const plan = computePlan(remote, local)
+    expect(plan.actions.every((a) => a.kind === "unchanged")).toBe(true)
+  })
+
+  test("remote.updated newer -> update", () => {
+    const local: LocalPostState[] = [
+      { id: "0123456789abcdef01234567", updatedAt: new Date(500 * 1000) },
+      { id: "fedcba9876543210fedcba98", updatedAt: new Date(2000 * 1000) },
+    ]
+    const plan = computePlan(remote, local)
+    const update = plan.actions.find((a) => a.kind === "update")
+    expect(update).toBeDefined()
+    if (update?.kind === "update")
+      expect(update.page.id).toBe("0123456789abcdef01234567")
+  })
+
+  test("local entry not in remote -> delete", () => {
+    const local: LocalPostState[] = [
+      { id: "0123456789abcdef01234567", updatedAt: new Date(1000 * 1000) },
+      { id: "ffffffffffffffffffffffff", updatedAt: new Date(0) },
+    ]
+    const plan = computePlan(remote, local)
+    expect(plan.actions.find((a) => a.kind === "delete")).toEqual({
+      kind: "delete",
+      id: "ffffffffffffffffffffffff",
+    })
+  })
+})

--- a/lib/sync/diff.ts
+++ b/lib/sync/diff.ts
@@ -1,0 +1,32 @@
+import type { CosenseListEntry, SyncAction, SyncPlan } from "./types"
+
+export interface LocalPostState {
+  id: string
+  updatedAt: Date
+}
+
+export function computePlan(
+  remote: CosenseListEntry[],
+  local: LocalPostState[],
+): SyncPlan {
+  const actions: SyncAction[] = []
+  const localById = new Map(local.map((l) => [l.id, l]))
+
+  for (const page of remote) {
+    const cur = localById.get(page.id)
+    if (!cur) {
+      actions.push({ kind: "create", page })
+    } else if (Math.floor(cur.updatedAt.getTime() / 1000) < page.updated) {
+      actions.push({ kind: "update", page })
+    } else {
+      actions.push({ kind: "unchanged", id: page.id })
+    }
+    localById.delete(page.id)
+  }
+
+  for (const stale of localById.keys()) {
+    actions.push({ kind: "delete", id: stale })
+  }
+
+  return { actions, localCount: local.length }
+}

--- a/lib/sync/frontmatter.test.ts
+++ b/lib/sync/frontmatter.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "vitest"
+import { emitFrontmatter } from "./frontmatter"
+import type { Post } from "./types"
+
+const post: Post = {
+  id: "0123456789abcdef01234567",
+  title: "Sample Post",
+  createdAt: new Date("2026-05-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-05-04T12:34:56.000Z"),
+  description: "First line of the body, trimmed.",
+  tags: ["sample", "demo"],
+  body: "ignored by frontmatter emitter",
+  images: [],
+}
+
+test("emits keys in a stable order", () => {
+  expect(emitFrontmatter(post)).toBe(
+    [
+      "---",
+      "title: Sample Post",
+      "created_at: '2026-05-01T00:00:00.000Z'",
+      "updated_at: '2026-05-04T12:34:56.000Z'",
+      "path: /0123456789abcdef01234567",
+      "description: 'First line of the body, trimmed.'",
+      "tags:",
+      "  - sample",
+      "  - demo",
+      "---",
+      "",
+    ].join("\n"),
+  )
+})
+
+test("omits tags entirely when empty", () => {
+  const out = emitFrontmatter({ ...post, tags: [] })
+  expect(out).not.toContain("tags:")
+})
+
+test("escapes single quotes in title", () => {
+  const out = emitFrontmatter({ ...post, title: "Don't break" })
+  expect(out).toContain("title: \"Don't break\"")
+})

--- a/lib/sync/frontmatter.test.ts
+++ b/lib/sync/frontmatter.test.ts
@@ -38,7 +38,7 @@ test("omits tags entirely when empty", () => {
 
 test("escapes single quotes in title", () => {
   const out = emitFrontmatter({ ...post, title: "Don't break" })
-  expect(out).toContain("title: \"Don't break\"")
+  expect(out).toContain('title: "Don\'t break"')
 })
 
 test("rejects scalars with embedded newlines", () => {

--- a/lib/sync/frontmatter.test.ts
+++ b/lib/sync/frontmatter.test.ts
@@ -17,7 +17,7 @@ test("emits keys in a stable order", () => {
   expect(emitFrontmatter(post)).toBe(
     [
       "---",
-      "title: Sample Post",
+      "title: 'Sample Post'",
       "created_at: '2026-05-01T00:00:00.000Z'",
       "updated_at: '2026-05-04T12:34:56.000Z'",
       "path: /0123456789abcdef01234567",
@@ -39,4 +39,16 @@ test("omits tags entirely when empty", () => {
 test("escapes single quotes in title", () => {
   const out = emitFrontmatter({ ...post, title: "Don't break" })
   expect(out).toContain("title: \"Don't break\"")
+})
+
+test("rejects scalars with embedded newlines", () => {
+  expect(() =>
+    emitFrontmatter({ ...post, description: "first\nsecond" }),
+  ).toThrow(/newline/)
+})
+
+test("escapes backslash before quote in mixed-quote case", () => {
+  const out = emitFrontmatter({ ...post, title: "It's \\n literal" })
+  // Title quoted with double quotes; backslash doubled, then \n preserved.
+  expect(out).toContain(`title: "It's \\\\n literal"`)
 })

--- a/lib/sync/frontmatter.ts
+++ b/lib/sync/frontmatter.ts
@@ -2,7 +2,9 @@ import type { Post } from "./types"
 
 function quoteScalar(s: string): string {
   if (/[\n\r]/.test(s)) {
-    throw new Error(`frontmatter scalar must not contain newlines: ${JSON.stringify(s)}`)
+    throw new Error(
+      `frontmatter scalar must not contain newlines: ${JSON.stringify(s)}`,
+    )
   }
   // YAML: single-quote unless the value itself contains a single quote.
   // In that case use double quotes and escape backslashes (first) and

--- a/lib/sync/frontmatter.ts
+++ b/lib/sync/frontmatter.ts
@@ -1,0 +1,29 @@
+import type { Post } from "./types"
+
+function quoteIfNeeded(s: string): string {
+  // YAML: single-quote strings unless they themselves contain single quotes.
+  if (s.includes("'")) return `"${s.replace(/"/g, '\\"')}"`
+  return `'${s}'`
+}
+
+function plainOrQuoted(s: string): string {
+  // Strings that look "safe" (no special chars, no leading whitespace) can
+  // go unquoted. Frontmatter consumers (gray-matter via Velite) accept both.
+  if (/^[A-Za-z0-9 _.-]+$/.test(s) && s.trim() === s) return s
+  return quoteIfNeeded(s)
+}
+
+export function emitFrontmatter(post: Post): string {
+  const lines: string[] = ["---"]
+  lines.push(`title: ${plainOrQuoted(post.title)}`)
+  lines.push(`created_at: '${post.createdAt.toISOString()}'`)
+  lines.push(`updated_at: '${post.updatedAt.toISOString()}'`)
+  lines.push(`path: /${post.id}`)
+  lines.push(`description: ${quoteIfNeeded(post.description)}`)
+  if (post.tags.length > 0) {
+    lines.push("tags:")
+    for (const tag of post.tags) lines.push(`  - ${tag}`)
+  }
+  lines.push("---", "")
+  return lines.join("\n")
+}

--- a/lib/sync/frontmatter.ts
+++ b/lib/sync/frontmatter.ts
@@ -1,25 +1,26 @@
 import type { Post } from "./types"
 
-function quoteIfNeeded(s: string): string {
-  // YAML: single-quote strings unless they themselves contain single quotes.
-  if (s.includes("'")) return `"${s.replace(/"/g, '\\"')}"`
+function quoteScalar(s: string): string {
+  if (/[\n\r]/.test(s)) {
+    throw new Error(`frontmatter scalar must not contain newlines: ${JSON.stringify(s)}`)
+  }
+  // YAML: single-quote unless the value itself contains a single quote.
+  // In that case use double quotes and escape backslashes (first) and
+  // double quotes (second). Order matters — if we escaped " before \,
+  // the inserted backslashes would get doubled too.
+  if (s.includes("'")) {
+    return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`
+  }
   return `'${s}'`
-}
-
-function plainOrQuoted(s: string): string {
-  // Strings that look "safe" (no special chars, no leading whitespace) can
-  // go unquoted. Frontmatter consumers (gray-matter via Velite) accept both.
-  if (/^[A-Za-z0-9 _.-]+$/.test(s) && s.trim() === s) return s
-  return quoteIfNeeded(s)
 }
 
 export function emitFrontmatter(post: Post): string {
   const lines: string[] = ["---"]
-  lines.push(`title: ${plainOrQuoted(post.title)}`)
+  lines.push(`title: ${quoteScalar(post.title)}`)
   lines.push(`created_at: '${post.createdAt.toISOString()}'`)
   lines.push(`updated_at: '${post.updatedAt.toISOString()}'`)
   lines.push(`path: /${post.id}`)
-  lines.push(`description: ${quoteIfNeeded(post.description)}`)
+  lines.push(`description: ${quoteScalar(post.description)}`)
   if (post.tags.length > 0) {
     lines.push("tags:")
     for (const tag of post.tags) lines.push(`  - ${tag}`)

--- a/lib/sync/fs-writer.test.ts
+++ b/lib/sync/fs-writer.test.ts
@@ -1,0 +1,55 @@
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, expect, test } from "vitest"
+import { writePost, deletePost } from "./fs-writer"
+import type { Post } from "./types"
+
+let root: string
+beforeEach(() => {
+	root = mkdtempSync(join(tmpdir(), "sync-fs-"))
+})
+afterEach(() => {
+	rmSync(root, { recursive: true, force: true })
+})
+
+const post: Post = {
+	id: "0123456789abcdef01234567",
+	title: "Sample",
+	createdAt: new Date("2026-05-01T00:00:00.000Z"),
+	updatedAt: new Date("2026-05-04T00:00:00.000Z"),
+	description: "intro",
+	tags: [],
+	body: "Hello body.",
+	images: [],
+}
+
+test("writes index.md under content/posts/<id>/", async () => {
+	await writePost(post, root)
+	const out = readFileSync(join(root, post.id, "index.md"), "utf8")
+	expect(out).toContain("title: 'Sample'")
+	expect(out).toContain("\n\nHello body.\n")
+})
+
+test("second write with identical content does not change mtime", async () => {
+	await writePost(post, root)
+	const dest = join(root, post.id, "index.md")
+	const t1 = statSync(dest).mtimeMs
+	await new Promise((r) => setTimeout(r, 20))
+	await writePost(post, root)
+	expect(statSync(dest).mtimeMs).toBe(t1)
+})
+
+test("write with changed content overwrites", async () => {
+	await writePost(post, root)
+	await writePost({ ...post, body: "Different." }, root)
+	expect(readFileSync(join(root, post.id, "index.md"), "utf8")).toContain("Different.")
+})
+
+test("deletePost removes the directory", async () => {
+	writeFileSync(join(root, "to-delete.md"), "x")
+	await writePost(post, root)
+	await deletePost(post.id, root)
+	expect(() => statSync(join(root, post.id))).toThrow()
+	expect(readFileSync(join(root, "to-delete.md"), "utf8")).toBe("x")
+})

--- a/lib/sync/fs-writer.test.ts
+++ b/lib/sync/fs-writer.test.ts
@@ -1,61 +1,69 @@
-import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs"
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, expect, test } from "vitest"
-import { writePost, deletePost } from "./fs-writer"
+import { deletePost, writePost } from "./fs-writer"
 import type { Post } from "./types"
 
 let root: string
 beforeEach(() => {
-	root = mkdtempSync(join(tmpdir(), "sync-fs-"))
+  root = mkdtempSync(join(tmpdir(), "sync-fs-"))
 })
 afterEach(() => {
-	rmSync(root, { recursive: true, force: true })
+  rmSync(root, { recursive: true, force: true })
 })
 
 const post: Post = {
-	id: "0123456789abcdef01234567",
-	title: "Sample",
-	createdAt: new Date("2026-05-01T00:00:00.000Z"),
-	updatedAt: new Date("2026-05-04T00:00:00.000Z"),
-	description: "intro",
-	tags: [],
-	body: "Hello body.",
-	images: [],
+  id: "0123456789abcdef01234567",
+  title: "Sample",
+  createdAt: new Date("2026-05-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-05-04T00:00:00.000Z"),
+  description: "intro",
+  tags: [],
+  body: "Hello body.",
+  images: [],
 }
 
 test("writes index.md under content/posts/<id>/", async () => {
-	await writePost(post, root)
-	const out = readFileSync(join(root, post.id, "index.md"), "utf8")
-	expect(out).toContain("title: 'Sample'")
-	expect(out).toContain("\n\nHello body.\n")
+  await writePost(post, root)
+  const out = readFileSync(join(root, post.id, "index.md"), "utf8")
+  expect(out).toContain("title: 'Sample'")
+  expect(out).toContain("\n\nHello body.\n")
 })
 
 test("second write with identical content does not change mtime", async () => {
-	await writePost(post, root)
-	const dest = join(root, post.id, "index.md")
-	const t1 = statSync(dest).mtimeMs
-	await new Promise((r) => setTimeout(r, 20))
-	await writePost(post, root)
-	expect(statSync(dest).mtimeMs).toBe(t1)
+  await writePost(post, root)
+  const dest = join(root, post.id, "index.md")
+  const t1 = statSync(dest).mtimeMs
+  await new Promise((r) => setTimeout(r, 20))
+  await writePost(post, root)
+  expect(statSync(dest).mtimeMs).toBe(t1)
 })
 
 test("write with changed content overwrites", async () => {
-	await writePost(post, root)
-	await writePost({ ...post, body: "Different." }, root)
-	expect(readFileSync(join(root, post.id, "index.md"), "utf8")).toContain("Different.")
+  await writePost(post, root)
+  await writePost({ ...post, body: "Different." }, root)
+  expect(readFileSync(join(root, post.id, "index.md"), "utf8")).toContain(
+    "Different.",
+  )
 })
 
 test("deletePost removes the directory", async () => {
-	writeFileSync(join(root, "to-delete.md"), "x")
-	await writePost(post, root)
-	await deletePost(post.id, root)
-	expect(() => statSync(join(root, post.id))).toThrow()
-	expect(readFileSync(join(root, "to-delete.md"), "utf8")).toBe("x")
+  writeFileSync(join(root, "to-delete.md"), "x")
+  await writePost(post, root)
+  await deletePost(post.id, root)
+  expect(() => statSync(join(root, post.id))).toThrow()
+  expect(readFileSync(join(root, "to-delete.md"), "utf8")).toBe("x")
 })
 
 test("does not leave a .tmp file when write succeeds", async () => {
-	await writePost(post, root)
-	const dest = join(root, post.id, "index.md")
-	expect(() => statSync(`${dest}.tmp`)).toThrow()
+  await writePost(post, root)
+  const dest = join(root, post.id, "index.md")
+  expect(() => statSync(`${dest}.tmp`)).toThrow()
 })

--- a/lib/sync/fs-writer.test.ts
+++ b/lib/sync/fs-writer.test.ts
@@ -53,3 +53,9 @@ test("deletePost removes the directory", async () => {
 	expect(() => statSync(join(root, post.id))).toThrow()
 	expect(readFileSync(join(root, "to-delete.md"), "utf8")).toBe("x")
 })
+
+test("does not leave a .tmp file when write succeeds", async () => {
+	await writePost(post, root)
+	const dest = join(root, post.id, "index.md")
+	expect(() => statSync(`${dest}.tmp`)).toThrow()
+})

--- a/lib/sync/fs-writer.ts
+++ b/lib/sync/fs-writer.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs"
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { mkdir, readFile, rename, rm, unlink, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { emitFrontmatter } from "./frontmatter"
 import type { Post } from "./types"
@@ -19,11 +19,17 @@ export async function writePost(post: Post, postsRoot: string): Promise<void> {
 		const cur = await readFile(dest, "utf8")
 		if (cur === next) return
 	}
-	await writeFile(dest, next)
+	const tmp = `${dest}.tmp`
+	await writeFile(tmp, next)
+	try {
+		await rename(tmp, dest)
+	} catch (err) {
+		await unlink(tmp).catch(() => {})
+		throw err
+	}
 }
 
 export async function deletePost(id: string, postsRoot: string): Promise<void> {
 	const dir = join(postsRoot, id)
-	if (!existsSync(dir)) return
 	await rm(dir, { recursive: true, force: true })
 }

--- a/lib/sync/fs-writer.ts
+++ b/lib/sync/fs-writer.ts
@@ -1,0 +1,29 @@
+import { existsSync } from "node:fs"
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import { emitFrontmatter } from "./frontmatter"
+import type { Post } from "./types"
+
+function render(post: Post): string {
+	const front = emitFrontmatter(post)
+	const body = post.body.endsWith("\n") ? post.body : `${post.body}\n`
+	return `${front}\n${body}`
+}
+
+export async function writePost(post: Post, postsRoot: string): Promise<void> {
+	const dir = join(postsRoot, post.id)
+	await mkdir(dir, { recursive: true })
+	const dest = join(dir, "index.md")
+	const next = render(post)
+	if (existsSync(dest)) {
+		const cur = await readFile(dest, "utf8")
+		if (cur === next) return
+	}
+	await writeFile(dest, next)
+}
+
+export async function deletePost(id: string, postsRoot: string): Promise<void> {
+	const dir = join(postsRoot, id)
+	if (!existsSync(dir)) return
+	await rm(dir, { recursive: true, force: true })
+}

--- a/lib/sync/fs-writer.ts
+++ b/lib/sync/fs-writer.ts
@@ -1,35 +1,42 @@
 import { existsSync } from "node:fs"
-import { mkdir, readFile, rename, rm, unlink, writeFile } from "node:fs/promises"
+import {
+  mkdir,
+  readFile,
+  rename,
+  rm,
+  unlink,
+  writeFile,
+} from "node:fs/promises"
 import { join } from "node:path"
 import { emitFrontmatter } from "./frontmatter"
 import type { Post } from "./types"
 
 function render(post: Post): string {
-	const front = emitFrontmatter(post)
-	const body = post.body.endsWith("\n") ? post.body : `${post.body}\n`
-	return `${front}\n${body}`
+  const front = emitFrontmatter(post)
+  const body = post.body.endsWith("\n") ? post.body : `${post.body}\n`
+  return `${front}\n${body}`
 }
 
 export async function writePost(post: Post, postsRoot: string): Promise<void> {
-	const dir = join(postsRoot, post.id)
-	await mkdir(dir, { recursive: true })
-	const dest = join(dir, "index.md")
-	const next = render(post)
-	if (existsSync(dest)) {
-		const cur = await readFile(dest, "utf8")
-		if (cur === next) return
-	}
-	const tmp = `${dest}.tmp`
-	await writeFile(tmp, next)
-	try {
-		await rename(tmp, dest)
-	} catch (err) {
-		await unlink(tmp).catch(() => {})
-		throw err
-	}
+  const dir = join(postsRoot, post.id)
+  await mkdir(dir, { recursive: true })
+  const dest = join(dir, "index.md")
+  const next = render(post)
+  if (existsSync(dest)) {
+    const cur = await readFile(dest, "utf8")
+    if (cur === next) return
+  }
+  const tmp = `${dest}.tmp`
+  await writeFile(tmp, next)
+  try {
+    await rename(tmp, dest)
+  } catch (err) {
+    await unlink(tmp).catch(() => {})
+    throw err
+  }
 }
 
 export async function deletePost(id: string, postsRoot: string): Promise<void> {
-	const dir = join(postsRoot, id)
-	await rm(dir, { recursive: true, force: true })
+  const dir = join(postsRoot, id)
+  await rm(dir, { recursive: true, force: true })
 }

--- a/lib/sync/images.test.ts
+++ b/lib/sync/images.test.ts
@@ -1,0 +1,65 @@
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, expect, test, vi } from "vitest"
+import { downloadImages } from "./images"
+
+let dir: string
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "sync-img-"))
+})
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+test("downloads each image once", async () => {
+  const fetchMock = vi.fn(
+    async () => new Response(new Uint8Array([1, 2, 3]), { status: 200 }),
+  )
+  await downloadImages(
+    [
+      { url: "https://gyazo.com/a.png", filename: "a.png" },
+      { url: "https://gyazo.com/b.png", filename: "b.png" },
+    ],
+    dir,
+    { fetch: fetchMock },
+  )
+  expect(fetchMock).toHaveBeenCalledTimes(2)
+  expect(Buffer.from(readFileSync(join(dir, "a.png")))).toEqual(
+    Buffer.from([1, 2, 3]),
+  )
+  expect(Buffer.from(readFileSync(join(dir, "b.png")))).toEqual(
+    Buffer.from([1, 2, 3]),
+  )
+})
+
+test("skips files that already exist", async () => {
+  writeFileSync(join(dir, "a.png"), new Uint8Array([9]))
+  const fetchMock = vi.fn(
+    async () => new Response(new Uint8Array([1]), { status: 200 }),
+  )
+  await downloadImages(
+    [{ url: "https://gyazo.com/a.png", filename: "a.png" }],
+    dir,
+    { fetch: fetchMock },
+  )
+  expect(fetchMock).not.toHaveBeenCalled()
+  expect(statSync(join(dir, "a.png")).size).toBe(1)
+})
+
+test("propagates fetch failure", async () => {
+  const fetchMock = vi.fn(async () => new Response("nope", { status: 404 }))
+  await expect(
+    downloadImages(
+      [{ url: "https://gyazo.com/a.png", filename: "a.png" }],
+      dir,
+      { fetch: fetchMock },
+    ),
+  ).rejects.toThrow(/404/)
+})

--- a/lib/sync/images.test.ts
+++ b/lib/sync/images.test.ts
@@ -65,9 +65,9 @@ test("propagates fetch failure", async () => {
 })
 
 test("does not leave a .tmp file when fetch succeeds", async () => {
-  const fetchMock = vi.fn().mockResolvedValue(
-    new Response(new Uint8Array([5]), { status: 200 }),
-  )
+  const fetchMock = vi
+    .fn()
+    .mockResolvedValue(new Response(new Uint8Array([5]), { status: 200 }))
   await downloadImages(
     [{ url: "https://gyazo.com/c.png", filename: "c.png" }],
     dir,

--- a/lib/sync/images.test.ts
+++ b/lib/sync/images.test.ts
@@ -63,3 +63,18 @@ test("propagates fetch failure", async () => {
     ),
   ).rejects.toThrow(/404/)
 })
+
+test("does not leave a .tmp file when fetch succeeds", async () => {
+  const fetchMock = vi.fn().mockResolvedValue(
+    new Response(new Uint8Array([5]), { status: 200 }),
+  )
+  await downloadImages(
+    [{ url: "https://gyazo.com/c.png", filename: "c.png" }],
+    dir,
+    { fetch: fetchMock },
+  )
+  expect(Buffer.from(readFileSync(join(dir, "c.png")))).toEqual(
+    Buffer.from([5]),
+  )
+  expect(() => statSync(join(dir, "c.png.tmp"))).toThrow()
+})

--- a/lib/sync/images.ts
+++ b/lib/sync/images.ts
@@ -1,0 +1,24 @@
+import { existsSync } from "node:fs"
+import { writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import type { ImageRef } from "./types"
+
+export interface DownloadOptions {
+  fetch?: typeof globalThis.fetch
+}
+
+export async function downloadImages(
+  refs: ImageRef[],
+  targetDir: string,
+  opts: DownloadOptions = {},
+): Promise<void> {
+  const fetcher = opts.fetch ?? globalThis.fetch
+  for (const ref of refs) {
+    const dest = join(targetDir, ref.filename)
+    if (existsSync(dest)) continue
+    const r = await fetcher(ref.url)
+    if (!r.ok) throw new Error(`image fetch ${ref.url} -> ${r.status}`)
+    const buf = new Uint8Array(await r.arrayBuffer())
+    await writeFile(dest, buf)
+  }
+}

--- a/lib/sync/images.ts
+++ b/lib/sync/images.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs"
-import { writeFile } from "node:fs/promises"
+import { rename, unlink, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import type { ImageRef } from "./types"
 
@@ -19,6 +19,13 @@ export async function downloadImages(
     const r = await fetcher(ref.url)
     if (!r.ok) throw new Error(`image fetch ${ref.url} -> ${r.status}`)
     const buf = new Uint8Array(await r.arrayBuffer())
-    await writeFile(dest, buf)
+    const tmp = `${dest}.tmp`
+    await writeFile(tmp, buf)
+    try {
+      await rename(tmp, dest)
+    } catch (err) {
+      await unlink(tmp).catch(() => {})
+      throw err
+    }
   }
 }

--- a/lib/sync/redirects.test.ts
+++ b/lib/sync/redirects.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "vitest"
+import { emitRedirects, type RedirectSeedEntry } from "./redirects"
+
+describe("emitRedirects", () => {
+  test("empty seed -> empty string", () => {
+    expect(emitRedirects([])).toBe("")
+  })
+
+  test("emits one 308 line per entry", () => {
+    const seed: RedirectSeedEntry[] = [
+      { old_path: "/2025-purchases", new_id: "0123456789abcdef01234567" },
+      { old_path: "/php-replace-lf", new_id: "fedcba9876543210fedcba98" },
+    ]
+    expect(emitRedirects(seed)).toBe(
+      [
+        "/2025-purchases /0123456789abcdef01234567/ 308",
+        "/php-replace-lf /fedcba9876543210fedcba98/ 308",
+        "",
+      ].join("\n"),
+    )
+  })
+
+  test("throws on duplicate old_path", () => {
+    expect(() =>
+      emitRedirects([
+        { old_path: "/x", new_id: "0123456789abcdef01234567" },
+        { old_path: "/x", new_id: "fedcba9876543210fedcba98" },
+      ]),
+    ).toThrow(/duplicate/i)
+  })
+})

--- a/lib/sync/redirects.ts
+++ b/lib/sync/redirects.ts
@@ -1,0 +1,19 @@
+export interface RedirectSeedEntry {
+  old_path: string
+  new_id: string
+}
+
+export function emitRedirects(seed: RedirectSeedEntry[]): string {
+  if (seed.length === 0) return ""
+  const seen = new Set<string>()
+  const lines: string[] = []
+  for (const entry of seed) {
+    if (seen.has(entry.old_path)) {
+      throw new Error(`duplicate old_path in redirects seed: ${entry.old_path}`)
+    }
+    seen.add(entry.old_path)
+    lines.push(`${entry.old_path} /${entry.new_id}/ 308`)
+  }
+  lines.push("")
+  return lines.join("\n")
+}

--- a/lib/sync/scrapbox-to-md.test.ts
+++ b/lib/sync/scrapbox-to-md.test.ts
@@ -3,22 +3,30 @@ import { scrapboxToMarkdown } from "./scrapbox-to-md"
 
 describe("scrapboxToMarkdown", () => {
   const cases: Array<[label: string, input: string, expected: string]> = [
-    ["plain line",     "hello world",                    "hello world"],
-    ["bold via [* ]",  "[* very important]",              "**very important**"],
-    ["heading h3 [** ]", "[** medium]",                   "### medium"],
-    ["heading h2 [*** ]", "[*** big]",                    "## big"],
-    ["heading h1 [**** ]", "[**** huge]",                 "# huge"],
-    ["inline code",    "use `pnpm sync` daily",           "use `pnpm sync` daily"],
-    ["external url",   "[https://example.com Example]",   "[Example](https://example.com)"],
-    ["bare url",       "[https://example.com]",           "<https://example.com>"],
-    ["hashtag stays inline", "see #blog for more",        "see #blog for more"],
-    ["gyazo image",    "[https://gyazo.com/abc123]",      "![](abc123.png)"],
+    ["plain line", "hello world", "hello world"],
+    ["bold via [* ]", "[* very important]", "**very important**"],
+    ["heading h3 [** ]", "[** medium]", "### medium"],
+    ["heading h2 [*** ]", "[*** big]", "## big"],
+    ["heading h1 [**** ]", "[**** huge]", "# huge"],
+    ["inline code", "use `pnpm sync` daily", "use `pnpm sync` daily"],
+    [
+      "external url",
+      "[https://example.com Example]",
+      "[Example](https://example.com)",
+    ],
+    ["bare url", "[https://example.com]", "<https://example.com>"],
+    ["hashtag stays inline", "see #blog for more", "see #blog for more"],
+    ["gyazo image", "[https://gyazo.com/abc123]", "![](abc123.png)"],
     ["scrapbox image", "[https://scrapbox.io/files/xyz.png]", "![](xyz.png)"],
-    ["internal link",  "[Other Page]",                    "**Other Page**"],
-    ["blockquote",     "> quoted",                         "> quoted"],
-    ["heading clamps 5+ stars to h1", "[***** mega]",     "# mega"],
-    ["whitespace-only bracket stays as-is", "[   ]",      "[   ]"],
-    ["bare url with trailing period", "[https://example.com.]", "<https://example.com>."],
+    ["internal link", "[Other Page]", "**Other Page**"],
+    ["blockquote", "> quoted", "> quoted"],
+    ["heading clamps 5+ stars to h1", "[***** mega]", "# mega"],
+    ["whitespace-only bracket stays as-is", "[   ]", "[   ]"],
+    [
+      "bare url with trailing period",
+      "[https://example.com.]",
+      "<https://example.com>.",
+    ],
   ]
   for (const [label, input, expected] of cases) {
     test(label, () => {

--- a/lib/sync/scrapbox-to-md.test.ts
+++ b/lib/sync/scrapbox-to-md.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "vitest"
+import { scrapboxToMarkdown } from "./scrapbox-to-md"
+
+describe("scrapboxToMarkdown", () => {
+  const cases: Array<[label: string, input: string, expected: string]> = [
+    ["plain line",     "hello world",                    "hello world"],
+    ["bold via [* ]",  "[* very important]",              "**very important**"],
+    ["heading h3 [** ]", "[** medium]",                   "### medium"],
+    ["heading h2 [*** ]", "[*** big]",                    "## big"],
+    ["heading h1 [**** ]", "[**** huge]",                 "# huge"],
+    ["inline code",    "use `pnpm sync` daily",           "use `pnpm sync` daily"],
+    ["external url",   "[https://example.com Example]",   "[Example](https://example.com)"],
+    ["bare url",       "[https://example.com]",           "<https://example.com>"],
+    ["hashtag stays inline", "see #blog for more",        "see #blog for more"],
+    ["gyazo image",    "[https://gyazo.com/abc123]",      "![](abc123.png)"],
+    ["scrapbox image", "[https://scrapbox.io/files/xyz.png]", "![](xyz.png)"],
+    ["internal link",  "[Other Page]",                    "**Other Page**"],
+    ["blockquote",     "> quoted",                         "> quoted"],
+  ]
+  for (const [label, input, expected] of cases) {
+    test(label, () => {
+      expect(scrapboxToMarkdown(input)).toBe(expected)
+    })
+  }
+
+  test("multi-line body keeps order and blank lines", () => {
+    const input = "[**** Title]\n\nIntro paragraph\n\n[* note]"
+    expect(scrapboxToMarkdown(input)).toBe(
+      "# Title\n\nIntro paragraph\n\n**note**",
+    )
+  })
+
+  test("fenced code block: 'code:filename.ts' followed by indented lines", () => {
+    const input = "code:hello.ts\n const x = 1\n const y = 2"
+    expect(scrapboxToMarkdown(input)).toBe(
+      "```ts\nconst x = 1\nconst y = 2\n```",
+    )
+  })
+})

--- a/lib/sync/scrapbox-to-md.test.ts
+++ b/lib/sync/scrapbox-to-md.test.ts
@@ -16,6 +16,9 @@ describe("scrapboxToMarkdown", () => {
     ["scrapbox image", "[https://scrapbox.io/files/xyz.png]", "![](xyz.png)"],
     ["internal link",  "[Other Page]",                    "**Other Page**"],
     ["blockquote",     "> quoted",                         "> quoted"],
+    ["heading clamps 5+ stars to h1", "[***** mega]",     "# mega"],
+    ["whitespace-only bracket stays as-is", "[   ]",      "[   ]"],
+    ["bare url with trailing period", "[https://example.com.]", "<https://example.com>."],
   ]
   for (const [label, input, expected] of cases) {
     test(label, () => {

--- a/lib/sync/scrapbox-to-md.ts
+++ b/lib/sync/scrapbox-to-md.ts
@@ -1,0 +1,63 @@
+// lib/sync/scrapbox-to-md.ts
+//
+// Pure (string) => string translator. Handles only the notation that
+// the test table covers. New notation discovered in real Cosense
+// content adds a row to the table FIRST, then is implemented here.
+
+const HEADING_LEVELS: Record<number, string> = { 4: "#", 3: "##", 2: "###" }
+
+const GYAZO_RE = /^\[https:\/\/gyazo\.com\/([a-zA-Z0-9]+)(?:\.[a-z]+)?\]$/
+const SCRAPBOX_FILE_RE =
+  /^\[https:\/\/scrapbox\.io\/files\/([a-zA-Z0-9]+\.[a-z]+)\]$/
+const URL_TITLE_RE = /^\[(https?:\/\/\S+)\s+(.+)\]$/
+const URL_BARE_RE = /^\[(https?:\/\/\S+)\]$/
+const STAR_RE = /^\[(\*+)\s+(.+)\]$/
+const INTERNAL_RE = /^\[([^\]]+)\]$/
+const CODE_OPEN_RE = /^code:([^\s]+)$/
+
+function transformInline(line: string): string {
+  // Whole-line wrappers handled first.
+  let m: RegExpMatchArray | null
+  if ((m = line.match(GYAZO_RE))) return `![](${m[1]}.png)`
+  if ((m = line.match(SCRAPBOX_FILE_RE))) return `![](${m[1]})`
+  if ((m = line.match(URL_TITLE_RE))) return `[${m[2]}](${m[1]})`
+  if ((m = line.match(URL_BARE_RE))) return `<${m[1]}>`
+  if ((m = line.match(STAR_RE))) {
+    const stars = m[1].length
+    const text = m[2]
+    return stars === 1
+      ? `**${text}**`
+      : `${HEADING_LEVELS[stars] ?? "###"} ${text}`
+  }
+  if ((m = line.match(INTERNAL_RE)) && !m[1].startsWith("http")) {
+    return `**${m[1]}**`
+  }
+  return line
+}
+
+export function scrapboxToMarkdown(input: string): string {
+  const lines = input.split("\n")
+  const out: string[] = []
+  let i = 0
+  while (i < lines.length) {
+    const raw = lines[i]
+    const codeOpen = raw.match(CODE_OPEN_RE)
+    if (codeOpen) {
+      const filename = codeOpen[1]
+      const ext = filename.includes(".") ? filename.split(".").pop()! : ""
+      const code: string[] = []
+      i++
+      while (i < lines.length && lines[i].startsWith(" ")) {
+        code.push(lines[i].slice(1))
+        i++
+      }
+      out.push("```" + ext)
+      out.push(...code)
+      out.push("```")
+      continue
+    }
+    out.push(transformInline(raw))
+    i++
+  }
+  return out.join("\n")
+}

--- a/lib/sync/scrapbox-to-md.ts
+++ b/lib/sync/scrapbox-to-md.ts
@@ -18,20 +18,36 @@ const CODE_OPEN_RE = /^code:([^\s]+)$/
 function transformInline(line: string): string {
   // Whole-line wrappers handled first.
   let m: RegExpMatchArray | null
-  if ((m = line.match(GYAZO_RE))) return `![](${m[1]}.png)`
-  if ((m = line.match(SCRAPBOX_FILE_RE))) return `![](${m[1]})`
-  if ((m = line.match(URL_TITLE_RE))) return `[${m[2]}](${m[1]})`
-  if ((m = line.match(URL_BARE_RE))) return `<${m[1]}>${m[2]}`
-  if ((m = line.match(STAR_RE))) {
+
+  m = line.match(GYAZO_RE)
+  if (m) return `![](${m[1]}.png)`
+
+  m = line.match(SCRAPBOX_FILE_RE)
+  if (m) return `![](${m[1]})`
+
+  m = line.match(URL_TITLE_RE)
+  if (m) return `[${m[2]}](${m[1]})`
+
+  m = line.match(URL_BARE_RE)
+  if (m) return `<${m[1]}>${m[2]}`
+
+  m = line.match(STAR_RE)
+  if (m) {
     const stars = m[1].length
     const text = m[2]
     return stars === 1
       ? `**${text}**`
       : `${HEADING_LEVELS[stars as 2 | 3 | 4] ?? "#"} ${text}`
   }
-  if ((m = line.match(INTERNAL_RE)) && !m[1].startsWith("http")) {
+
+  m = line.match(INTERNAL_RE)
+  if (m && !m[1].startsWith("http")) {
     const content = m[1]
-    if (content.length > 0 && !/^\s/.test(content) && content.trim().length > 0) {
+    if (
+      content.length > 0 &&
+      !/^\s/.test(content) &&
+      content.trim().length > 0
+    ) {
       return `**${content}**`
     }
   }
@@ -54,7 +70,7 @@ export function scrapboxToMarkdown(input: string): string {
         code.push(lines[i].slice(1))
         i++
       }
-      out.push("```" + ext)
+      out.push(`\`\`\`${ext}`)
       out.push(...code)
       out.push("```")
       continue

--- a/lib/sync/scrapbox-to-md.ts
+++ b/lib/sync/scrapbox-to-md.ts
@@ -4,13 +4,13 @@
 // the test table covers. New notation discovered in real Cosense
 // content adds a row to the table FIRST, then is implemented here.
 
-const HEADING_LEVELS: Record<number, string> = { 4: "#", 3: "##", 2: "###" }
+const HEADING_LEVELS: Record<2 | 3 | 4, string> = { 4: "#", 3: "##", 2: "###" }
 
 const GYAZO_RE = /^\[https:\/\/gyazo\.com\/([a-zA-Z0-9]+)(?:\.[a-z]+)?\]$/
 const SCRAPBOX_FILE_RE =
   /^\[https:\/\/scrapbox\.io\/files\/([a-zA-Z0-9]+\.[a-z]+)\]$/
 const URL_TITLE_RE = /^\[(https?:\/\/\S+)\s+(.+)\]$/
-const URL_BARE_RE = /^\[(https?:\/\/\S+)\]$/
+const URL_BARE_RE = /^\[(https?:\/\/[^\s\]]+?)([.,;:!?]?)\]$/
 const STAR_RE = /^\[(\*+)\s+(.+)\]$/
 const INTERNAL_RE = /^\[([^\]]+)\]$/
 const CODE_OPEN_RE = /^code:([^\s]+)$/
@@ -21,16 +21,19 @@ function transformInline(line: string): string {
   if ((m = line.match(GYAZO_RE))) return `![](${m[1]}.png)`
   if ((m = line.match(SCRAPBOX_FILE_RE))) return `![](${m[1]})`
   if ((m = line.match(URL_TITLE_RE))) return `[${m[2]}](${m[1]})`
-  if ((m = line.match(URL_BARE_RE))) return `<${m[1]}>`
+  if ((m = line.match(URL_BARE_RE))) return `<${m[1]}>${m[2]}`
   if ((m = line.match(STAR_RE))) {
     const stars = m[1].length
     const text = m[2]
     return stars === 1
       ? `**${text}**`
-      : `${HEADING_LEVELS[stars] ?? "###"} ${text}`
+      : `${HEADING_LEVELS[stars as 2 | 3 | 4] ?? "#"} ${text}`
   }
   if ((m = line.match(INTERNAL_RE)) && !m[1].startsWith("http")) {
-    return `**${m[1]}**`
+    const content = m[1]
+    if (content.length > 0 && !/^\s/.test(content) && content.trim().length > 0) {
+      return `**${content}**`
+    }
   }
   return line
 }

--- a/lib/sync/slug.test.ts
+++ b/lib/sync/slug.test.ts
@@ -11,3 +11,7 @@ test("rejects non-id input", () => {
   expect(isValidSlug("Not An Id")).toBe(false)
   expect(isValidSlug("0123456789abcdef01234567")).toBe(true)
 })
+
+test("slugForPageId throws with descriptive message on invalid input", () => {
+  expect(() => slugForPageId("not-a-page-id")).toThrow(/invalid Cosense page id/)
+})

--- a/lib/sync/slug.test.ts
+++ b/lib/sync/slug.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "vitest"
+import { isValidSlug, slugForPageId } from "./slug"
+
+test("page id passes through verbatim", () => {
+  expect(slugForPageId("0123456789abcdef01234567")).toBe(
+    "0123456789abcdef01234567",
+  )
+})
+
+test("rejects non-id input", () => {
+  expect(isValidSlug("Not An Id")).toBe(false)
+  expect(isValidSlug("0123456789abcdef01234567")).toBe(true)
+})

--- a/lib/sync/slug.test.ts
+++ b/lib/sync/slug.test.ts
@@ -13,5 +13,7 @@ test("rejects non-id input", () => {
 })
 
 test("slugForPageId throws with descriptive message on invalid input", () => {
-  expect(() => slugForPageId("not-a-page-id")).toThrow(/invalid Cosense page id/)
+  expect(() => slugForPageId("not-a-page-id")).toThrow(
+    /invalid Cosense page id/,
+  )
 })

--- a/lib/sync/slug.ts
+++ b/lib/sync/slug.ts
@@ -1,0 +1,12 @@
+const PAGE_ID_RE = /^[a-f0-9]{24}$/
+
+export function slugForPageId(pageId: string): string {
+  if (!PAGE_ID_RE.test(pageId)) {
+    throw new Error(`invalid Cosense page id: ${pageId}`)
+  }
+  return pageId
+}
+
+export function isValidSlug(s: string): boolean {
+  return PAGE_ID_RE.test(s)
+}

--- a/lib/sync/slug.ts
+++ b/lib/sync/slug.ts
@@ -1,4 +1,4 @@
-const PAGE_ID_RE = /^[a-f0-9]{24}$/
+import { PAGE_ID_RE } from "./types"
 
 export function slugForPageId(pageId: string): string {
   if (!PAGE_ID_RE.test(pageId)) {

--- a/lib/sync/transform.test.ts
+++ b/lib/sync/transform.test.ts
@@ -33,3 +33,43 @@ test("description falls back to empty string when body has no prose", () => {
   const post = transformPage({ ...page, lines: [page.lines[0]] })
   expect(post.description).toBe("")
 })
+
+test("description skips code: and blockquote lines", () => {
+  const post = transformPage({
+    ...page,
+    lines: [
+      page.lines[0],
+      { id: "x", text: "code:hello.ts", userId: "u", created: 1, updated: 1 },
+      { id: "y", text: " const x = 1", userId: "u", created: 1, updated: 1 },
+      { id: "z", text: "> quoted", userId: "u", created: 1, updated: 1 },
+      { id: "w", text: "real prose here", userId: "u", created: 1, updated: 1 },
+    ],
+  })
+  expect(post.description).toBe("real prose here")
+})
+
+test("does not eat first body line when title differs from lines[0]", () => {
+  const post = transformPage({
+    ...page,
+    title: "Renamed",
+    lines: [
+      { id: "l1", text: "Original Body Line", userId: "u", created: 1, updated: 1 },
+      { id: "l2", text: "Second", userId: "u", created: 1, updated: 1 },
+    ],
+  })
+  expect(post.description).toBe("Original Body Line")
+  expect(post.body).toContain("Original Body Line")
+})
+
+test("hashtag dedup + scrapbox file image", () => {
+  const post = transformPage({
+    ...page,
+    lines: [
+      page.lines[0],
+      { id: "a", text: "see #blog and #blog again", userId: "u", created: 1, updated: 1 },
+      { id: "b", text: "[https://scrapbox.io/files/abc.jpg]", userId: "u", created: 1, updated: 1 },
+    ],
+  })
+  expect(post.tags).toEqual(["blog"])
+  expect(post.images).toEqual([{ url: "https://scrapbox.io/files/abc.jpg", filename: "abc.jpg" }])
+})

--- a/lib/sync/transform.test.ts
+++ b/lib/sync/transform.test.ts
@@ -8,10 +8,22 @@ const page: CosensePage = {
   created: 1714521600,
   updated: 1714694400,
   lines: [
-    { id: "l1", text: "First Post",                           userId: "u", created: 1, updated: 1 },
-    { id: "l2", text: "Intro paragraph.",                     userId: "u", created: 1, updated: 1 },
-    { id: "l3", text: "Body line with #blog #demo tags",      userId: "u", created: 1, updated: 1 },
-    { id: "l4", text: "[https://gyazo.com/ABCDEF123456.png]", userId: "u", created: 1, updated: 1 },
+    { id: "l1", text: "First Post", userId: "u", created: 1, updated: 1 },
+    { id: "l2", text: "Intro paragraph.", userId: "u", created: 1, updated: 1 },
+    {
+      id: "l3",
+      text: "Body line with #blog #demo tags",
+      userId: "u",
+      created: 1,
+      updated: 1,
+    },
+    {
+      id: "l4",
+      text: "[https://gyazo.com/ABCDEF123456.png]",
+      userId: "u",
+      created: 1,
+      updated: 1,
+    },
   ],
 }
 
@@ -19,7 +31,9 @@ test("strips title line and emits IR", () => {
   const post = transformPage(page)
   expect(post.id).toBe("0123456789abcdef01234567")
   expect(post.title).toBe("First Post")
-  expect(post.createdAt.toISOString()).toBe(new Date(1714521600 * 1000).toISOString())
+  expect(post.createdAt.toISOString()).toBe(
+    new Date(1714521600 * 1000).toISOString(),
+  )
   expect(post.description).toBe("Intro paragraph.")
   expect(post.tags).toEqual(["blog", "demo"])
   expect(post.body).toContain("Intro paragraph.")
@@ -53,7 +67,13 @@ test("does not eat first body line when title differs from lines[0]", () => {
     ...page,
     title: "Renamed",
     lines: [
-      { id: "l1", text: "Original Body Line", userId: "u", created: 1, updated: 1 },
+      {
+        id: "l1",
+        text: "Original Body Line",
+        userId: "u",
+        created: 1,
+        updated: 1,
+      },
       { id: "l2", text: "Second", userId: "u", created: 1, updated: 1 },
     ],
   })
@@ -66,10 +86,24 @@ test("hashtag dedup + scrapbox file image", () => {
     ...page,
     lines: [
       page.lines[0],
-      { id: "a", text: "see #blog and #blog again", userId: "u", created: 1, updated: 1 },
-      { id: "b", text: "[https://scrapbox.io/files/abc.jpg]", userId: "u", created: 1, updated: 1 },
+      {
+        id: "a",
+        text: "see #blog and #blog again",
+        userId: "u",
+        created: 1,
+        updated: 1,
+      },
+      {
+        id: "b",
+        text: "[https://scrapbox.io/files/abc.jpg]",
+        userId: "u",
+        created: 1,
+        updated: 1,
+      },
     ],
   })
   expect(post.tags).toEqual(["blog"])
-  expect(post.images).toEqual([{ url: "https://scrapbox.io/files/abc.jpg", filename: "abc.jpg" }])
+  expect(post.images).toEqual([
+    { url: "https://scrapbox.io/files/abc.jpg", filename: "abc.jpg" },
+  ])
 })

--- a/lib/sync/transform.test.ts
+++ b/lib/sync/transform.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "vitest"
+import { transformPage } from "./transform"
+import type { CosensePage } from "./types"
+
+const page: CosensePage = {
+  id: "0123456789abcdef01234567",
+  title: "First Post",
+  created: 1714521600,
+  updated: 1714694400,
+  lines: [
+    { id: "l1", text: "First Post",                           userId: "u", created: 1, updated: 1 },
+    { id: "l2", text: "Intro paragraph.",                     userId: "u", created: 1, updated: 1 },
+    { id: "l3", text: "Body line with #blog #demo tags",      userId: "u", created: 1, updated: 1 },
+    { id: "l4", text: "[https://gyazo.com/ABCDEF123456.png]", userId: "u", created: 1, updated: 1 },
+  ],
+}
+
+test("strips title line and emits IR", () => {
+  const post = transformPage(page)
+  expect(post.id).toBe("0123456789abcdef01234567")
+  expect(post.title).toBe("First Post")
+  expect(post.createdAt.toISOString()).toBe(new Date(1714521600 * 1000).toISOString())
+  expect(post.description).toBe("Intro paragraph.")
+  expect(post.tags).toEqual(["blog", "demo"])
+  expect(post.body).toContain("Intro paragraph.")
+  expect(post.body).not.toContain("First Post\n")
+  expect(post.images).toEqual([
+    { url: "https://gyazo.com/ABCDEF123456.png", filename: "ABCDEF123456.png" },
+  ])
+})
+
+test("description falls back to empty string when body has no prose", () => {
+  const post = transformPage({ ...page, lines: [page.lines[0]] })
+  expect(post.description).toBe("")
+})

--- a/lib/sync/transform.ts
+++ b/lib/sync/transform.ts
@@ -1,0 +1,53 @@
+import { scrapboxToMarkdown } from "./scrapbox-to-md"
+import type { CosensePage, ImageRef, Post } from "./types"
+
+const HASHTAG_RE = /(?:^|\s)#([\p{L}\p{N}_-]+)/gu
+const GYAZO_RE = /\[https:\/\/gyazo\.com\/([a-zA-Z0-9]+)(\.[a-z]+)?\]/g
+const SCRAPBOX_FILE_RE = /\[https:\/\/scrapbox\.io\/files\/([a-zA-Z0-9]+\.[a-z]+)\]/g
+
+function extractTags(text: string): string[] {
+  const out = new Set<string>()
+  for (const m of text.matchAll(HASHTAG_RE)) out.add(m[1])
+  return [...out]
+}
+
+function extractImages(text: string): ImageRef[] {
+  const out: ImageRef[] = []
+  for (const m of text.matchAll(GYAZO_RE)) {
+    const ext = m[2] ?? ".png"
+    out.push({ url: `https://gyazo.com/${m[1]}${ext}`, filename: `${m[1]}${ext}` })
+  }
+  for (const m of text.matchAll(SCRAPBOX_FILE_RE)) {
+    out.push({
+      url: `https://scrapbox.io/files/${m[1]}`,
+      filename: m[1],
+    })
+  }
+  return out
+}
+
+function firstProseLine(bodyLines: string[]): string {
+  for (const l of bodyLines) {
+    const trimmed = l.trim()
+    if (trimmed.length === 0) continue
+    if (trimmed.startsWith("#")) continue // hashtag-only line
+    if (trimmed.startsWith("[")) continue // image / heading line
+    return trimmed.length > 160 ? trimmed.slice(0, 160) : trimmed
+  }
+  return ""
+}
+
+export function transformPage(page: CosensePage): Post {
+  const bodyLines = page.lines.slice(1).map((l) => l.text)
+  const rawBody = bodyLines.join("\n")
+  return {
+    id: page.id,
+    title: page.title,
+    createdAt: new Date(page.created * 1000),
+    updatedAt: new Date(page.updated * 1000),
+    description: firstProseLine(bodyLines),
+    tags: extractTags(rawBody),
+    body: scrapboxToMarkdown(rawBody),
+    images: extractImages(rawBody),
+  }
+}

--- a/lib/sync/transform.ts
+++ b/lib/sync/transform.ts
@@ -3,7 +3,8 @@ import type { CosensePage, ImageRef, Post } from "./types"
 
 const HASHTAG_RE = /(?:^|\s)#([\p{L}\p{N}_-]+)/gu
 const GYAZO_RE = /\[https:\/\/gyazo\.com\/([a-zA-Z0-9]+)(\.[a-z]+)?\]/g
-const SCRAPBOX_FILE_RE = /\[https:\/\/scrapbox\.io\/files\/([a-zA-Z0-9]+\.[a-z]+)\]/g
+const SCRAPBOX_FILE_RE =
+  /\[https:\/\/scrapbox\.io\/files\/([a-zA-Z0-9]+\.[a-z]+)\]/g
 
 const DESCRIPTION_MAX = 160
 
@@ -17,7 +18,10 @@ function extractImages(text: string): ImageRef[] {
   const out: ImageRef[] = []
   for (const m of text.matchAll(GYAZO_RE)) {
     const ext = m[2] ?? ".png"
-    out.push({ url: `https://gyazo.com/${m[1]}${ext}`, filename: `${m[1]}${ext}` })
+    out.push({
+      url: `https://gyazo.com/${m[1]}${ext}`,
+      filename: `${m[1]}${ext}`,
+    })
   }
   for (const m of text.matchAll(SCRAPBOX_FILE_RE)) {
     out.push({
@@ -37,7 +41,9 @@ function firstProseLine(bodyLines: string[]): string {
     if (trimmed.startsWith("code:")) continue // fenced-code opener
     if (trimmed.startsWith(">")) continue // blockquote
     if (l !== trimmed && trimmed.length > 0) continue // indented line (code content)
-    return trimmed.length > DESCRIPTION_MAX ? trimmed.slice(0, DESCRIPTION_MAX) : trimmed
+    return trimmed.length > DESCRIPTION_MAX
+      ? trimmed.slice(0, DESCRIPTION_MAX)
+      : trimmed
   }
   return ""
 }

--- a/lib/sync/transform.ts
+++ b/lib/sync/transform.ts
@@ -5,6 +5,8 @@ const HASHTAG_RE = /(?:^|\s)#([\p{L}\p{N}_-]+)/gu
 const GYAZO_RE = /\[https:\/\/gyazo\.com\/([a-zA-Z0-9]+)(\.[a-z]+)?\]/g
 const SCRAPBOX_FILE_RE = /\[https:\/\/scrapbox\.io\/files\/([a-zA-Z0-9]+\.[a-z]+)\]/g
 
+const DESCRIPTION_MAX = 160
+
 function extractTags(text: string): string[] {
   const out = new Set<string>()
   for (const m of text.matchAll(HASHTAG_RE)) out.add(m[1])
@@ -31,14 +33,18 @@ function firstProseLine(bodyLines: string[]): string {
     const trimmed = l.trim()
     if (trimmed.length === 0) continue
     if (trimmed.startsWith("#")) continue // hashtag-only line
-    if (trimmed.startsWith("[")) continue // image / heading line
-    return trimmed.length > 160 ? trimmed.slice(0, 160) : trimmed
+    if (trimmed.startsWith("[")) continue // image / heading / link line
+    if (trimmed.startsWith("code:")) continue // fenced-code opener
+    if (trimmed.startsWith(">")) continue // blockquote
+    if (l !== trimmed && trimmed.length > 0) continue // indented line (code content)
+    return trimmed.length > DESCRIPTION_MAX ? trimmed.slice(0, DESCRIPTION_MAX) : trimmed
   }
   return ""
 }
 
 export function transformPage(page: CosensePage): Post {
-  const bodyLines = page.lines.slice(1).map((l) => l.text)
+  const skipTitle = page.lines[0]?.text === page.title ? 1 : 0
+  const bodyLines = page.lines.slice(skipTitle).map((l) => l.text)
   const rawBody = bodyLines.join("\n")
   return {
     id: page.id,

--- a/lib/sync/types.ts
+++ b/lib/sync/types.ts
@@ -1,0 +1,64 @@
+import { z } from "zod"
+
+/** Cosense page object as returned by /api/pages/<project>/<title>. */
+export const cosensePageSchema = z.object({
+  id: z.string().regex(/^[a-f0-9]{24}$/),
+  title: z.string().min(1),
+  created: z.number().int().nonnegative(),
+  updated: z.number().int().nonnegative(),
+  lines: z.array(
+    z.object({
+      id: z.string(),
+      text: z.string(),
+      userId: z.string(),
+      created: z.number().int(),
+      updated: z.number().int(),
+    }),
+  ),
+})
+export type CosensePage = z.infer<typeof cosensePageSchema>
+
+/** Cosense list entry as returned by /api/pages/<project>. */
+export const cosenseListEntrySchema = z.object({
+  id: z.string().regex(/^[a-f0-9]{24}$/),
+  title: z.string().min(1),
+  updated: z.number().int().nonnegative(),
+})
+export type CosenseListEntry = z.infer<typeof cosenseListEntrySchema>
+
+export const cosenseListResponseSchema = z.object({
+  count: z.number().int().nonnegative(),
+  pages: z.array(cosenseListEntrySchema),
+})
+
+/** Internal Representation of a single blog post. */
+export interface Post {
+  id: string // Cosense page id, also the directory name + URL slug
+  title: string
+  createdAt: Date
+  updatedAt: Date
+  description: string // first non-empty body line, trimmed
+  tags: string[]
+  body: string // markdown body without frontmatter
+  images: ImageRef[] // images referenced by body, downloaded by sync
+}
+
+export interface ImageRef {
+  /** URL on Cosense / Gyazo / scrapbox.io. */
+  url: string
+  /** Filename used inside the post directory (also referenced by body). */
+  filename: string
+}
+
+/** Output of diff stage. */
+export type SyncAction =
+  | { kind: "create"; page: CosenseListEntry }
+  | { kind: "update"; page: CosenseListEntry }
+  | { kind: "delete"; id: string }
+  | { kind: "unchanged"; id: string }
+
+export interface SyncPlan {
+  actions: SyncAction[]
+  /** Number of currently existing local post directories before sync. */
+  localCount: number
+}

--- a/lib/sync/types.ts
+++ b/lib/sync/types.ts
@@ -1,8 +1,11 @@
 import { z } from "zod"
 
+/** Cosense page id format: 24 lowercase hex characters. */
+export const PAGE_ID_RE = /^[a-f0-9]{24}$/
+
 /** Cosense page object as returned by /api/pages/<project>/<title>. */
 export const cosensePageSchema = z.object({
-  id: z.string().regex(/^[a-f0-9]{24}$/),
+  id: z.string().regex(PAGE_ID_RE),
   title: z.string().min(1),
   created: z.number().int().nonnegative(),
   updated: z.number().int().nonnegative(),
@@ -20,7 +23,7 @@ export type CosensePage = z.infer<typeof cosensePageSchema>
 
 /** Cosense list entry as returned by /api/pages/<project>. */
 export const cosenseListEntrySchema = z.object({
-  id: z.string().regex(/^[a-f0-9]{24}$/),
+  id: z.string().regex(PAGE_ID_RE),
   title: z.string().min(1),
   updated: z.number().int().nonnegative(),
 })

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "react-share": "5.3.0",
     "rehype-pretty-code": "^0.14.3",
     "shiki": "^4.0.2",
-    "unist-util-visit": "^5.1.0"
+    "unist-util-visit": "^5.1.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.14",
@@ -39,7 +40,8 @@
     "tsx": "^4",
     "typescript": "5.9.3",
     "velite": "^0.3",
-    "vite": "^8.0.10"
+    "vite": "^8.0.10",
+    "vitest": "^2.1.0"
   },
   "keywords": [
     "blog",
@@ -61,6 +63,9 @@
     "lint:ci": "biome ci .",
     "lint:text": "textlint content/**/index.md",
     "lint:textfix": "textlint --fix content/**/index.md",
+    "sync": "tsx scripts/sync-cosense.ts",
+    "test:unit": "vitest run",
+    "test:unit:watch": "vitest",
     "test": "tsc -p ./tsconfig.json"
   },
   "packageManager": "pnpm@9.15.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       unist-util-visit:
         specifier: ^5.1.0
         version: 5.1.0
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
     devDependencies:
       '@biomejs/biome':
         specifier: 2.4.14
@@ -136,6 +139,9 @@ importers:
       vite:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@22.19.17)(lightningcss@1.32.0)(terser@5.44.1)
 
 packages:
 
@@ -300,6 +306,12 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
     engines: {node: '>=18'}
@@ -312,6 +324,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
@@ -322,6 +340,12 @@ packages:
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.25.12':
@@ -336,6 +360,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
@@ -348,6 +378,12 @@ packages:
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.25.12':
     resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
@@ -358,6 +394,12 @@ packages:
     resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.12':
@@ -372,6 +414,12 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.25.12':
     resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
@@ -382,6 +430,12 @@ packages:
     resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.12':
@@ -396,6 +450,12 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.25.12':
     resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
@@ -406,6 +466,12 @@ packages:
     resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.12':
@@ -420,6 +486,12 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.25.12':
     resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
@@ -430,6 +502,12 @@ packages:
     resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.12':
@@ -444,6 +522,12 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.25.12':
     resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
@@ -454,6 +538,12 @@ packages:
     resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.12':
@@ -468,6 +558,12 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.25.12':
     resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
@@ -480,6 +576,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
@@ -490,6 +592,12 @@ packages:
     resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
     engines: {node: '>=18'}
     cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.25.12':
@@ -516,6 +624,12 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.25.12':
     resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
     engines: {node: '>=18'}
@@ -538,6 +652,12 @@ packages:
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -564,6 +684,12 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.25.12':
     resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
     engines: {node: '>=18'}
@@ -575,6 +701,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
 
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
@@ -588,6 +720,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.25.12':
     resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
     engines: {node: '>=18'}
@@ -598,6 +736,12 @@ packages:
     resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.25.12':
@@ -957,6 +1101,131 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.7':
     resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
 
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    resolution: {integrity: sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    resolution: {integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    resolution: {integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    resolution: {integrity: sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    resolution: {integrity: sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    resolution: {integrity: sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
+    cpu: [x64]
+    os: [win32]
+
   '@shikijs/core@4.0.2':
     resolution: {integrity: sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==}
     engines: {node: '>=20'}
@@ -1253,6 +1522,35 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -1303,6 +1601,10 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
@@ -1366,6 +1668,10 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   cacheable@2.3.4:
     resolution: {integrity: sha512-djgxybDbw9fL/ZWMI3+CE8ZilNxcwFkVtDc1gJ+IlOSSWkSMPQabhV/XCHTQ6pwwN6aivXPZ43omTooZiX06Ew==}
 
@@ -1389,6 +1695,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1420,6 +1730,10 @@ packages:
 
   charenc@0.0.2:
     resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   cheerio-select@2.1.0:
     resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
@@ -1524,6 +1838,10 @@ packages:
   decode-named-character-reference@1.2.0:
     resolution: {integrity: sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==}
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -1610,6 +1928,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -1619,6 +1940,11 @@ packages:
 
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -1673,6 +1999,10 @@ packages:
   eventsource@3.0.7:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   express-rate-limit@8.4.1:
     resolution: {integrity: sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==}
@@ -2149,6 +2479,9 @@ packages:
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -2497,8 +2830,15 @@ packages:
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2668,6 +3008,11 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  rollup@4.60.2:
+    resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   rou3@0.8.1:
     resolution: {integrity: sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==}
 
@@ -2758,6 +3103,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -2811,9 +3159,15 @@ packages:
     engines: {node: '>=20.16.0'}
     hasBin: true
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -2938,9 +3292,27 @@ packages:
     engines: {node: '>=20.0.0'}
     hasBin: true
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -3083,6 +3455,42 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
   vite@8.0.10:
     resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -3134,6 +3542,31 @@ packages:
       vite:
         optional: true
 
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   web-namespaces@1.1.4:
     resolution: {integrity: sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==}
 
@@ -3155,6 +3588,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -3384,10 +3822,16 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
   '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.25.12':
@@ -3396,10 +3840,16 @@ snapshots:
   '@esbuild/android-arm64@0.27.7':
     optional: true
 
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
   '@esbuild/android-arm@0.25.12':
     optional: true
 
   '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.25.12':
@@ -3408,10 +3858,16 @@ snapshots:
   '@esbuild/android-x64@0.27.7':
     optional: true
 
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
   '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.25.12':
@@ -3420,10 +3876,16 @@ snapshots:
   '@esbuild/darwin-x64@0.27.7':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.12':
@@ -3432,10 +3894,16 @@ snapshots:
   '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
   '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.25.12':
@@ -3444,10 +3912,16 @@ snapshots:
   '@esbuild/linux-arm@0.27.7':
     optional: true
 
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
   '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.25.12':
@@ -3456,10 +3930,16 @@ snapshots:
   '@esbuild/linux-loong64@0.27.7':
     optional: true
 
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
   '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.12':
@@ -3468,16 +3948,25 @@ snapshots:
   '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
   '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
@@ -3492,6 +3981,9 @@ snapshots:
   '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
@@ -3502,6 +3994,9 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -3516,10 +4011,16 @@ snapshots:
   '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
   '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
@@ -3528,10 +4029,16 @@ snapshots:
   '@esbuild/win32-arm64@0.27.7':
     optional: true
 
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
   '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
@@ -3846,6 +4353,81 @@ snapshots:
   '@rolldown/pluginutils@1.0.0-rc.17': {}
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    optional: true
 
   '@shikijs/core@4.0.2':
     dependencies:
@@ -4280,6 +4862,46 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.7
       vite: 8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)
 
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.17)(lightningcss@1.32.0)(terser@5.44.1))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@22.19.17)(lightningcss@1.32.0)(terser@5.44.1)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -4322,6 +4944,8 @@ snapshots:
   app-root-path@3.1.0: {}
 
   argparse@2.0.1: {}
+
+  assertion-error@2.0.1: {}
 
   astral-regex@2.0.0: {}
 
@@ -4388,6 +5012,8 @@ snapshots:
 
   bytes@3.1.2: {}
 
+  cac@6.7.14: {}
+
   cacheable@2.3.4:
     dependencies:
       '@cacheable/memory': 2.0.8
@@ -4419,6 +5045,14 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -4441,6 +5075,8 @@ snapshots:
   chardet@2.1.1: {}
 
   charenc@0.0.2: {}
+
+  check-error@2.1.3: {}
 
   cheerio-select@2.1.0:
     dependencies:
@@ -4558,6 +5194,8 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
+  deep-eql@5.0.2: {}
+
   deep-is@0.1.4: {}
 
   define-data-property@1.1.4:
@@ -4633,6 +5271,8 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-module-lexer@1.7.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -4650,6 +5290,32 @@ snapshots:
       acorn: 8.15.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -4755,6 +5421,8 @@ snapshots:
   eventsource@3.0.7:
     dependencies:
       eventsource-parser: 3.0.8
+
+  expect-type@1.3.0: {}
 
   express-rate-limit@8.4.1(express@5.2.1):
     dependencies:
@@ -5271,6 +5939,8 @@ snapshots:
   longest-streak@2.0.4: {}
 
   longest-streak@3.1.0: {}
+
+  loupe@3.2.1: {}
 
   lru-cache@10.4.3: {}
 
@@ -5873,7 +6543,11 @@ snapshots:
 
   path-to-regexp@8.4.2: {}
 
+  pathe@1.1.2: {}
+
   pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -6121,6 +6795,37 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
 
+  rollup@4.60.2:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.2
+      '@rollup/rollup-android-arm64': 4.60.2
+      '@rollup/rollup-darwin-arm64': 4.60.2
+      '@rollup/rollup-darwin-x64': 4.60.2
+      '@rollup/rollup-freebsd-arm64': 4.60.2
+      '@rollup/rollup-freebsd-x64': 4.60.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.2
+      '@rollup/rollup-linux-arm64-gnu': 4.60.2
+      '@rollup/rollup-linux-arm64-musl': 4.60.2
+      '@rollup/rollup-linux-loong64-gnu': 4.60.2
+      '@rollup/rollup-linux-loong64-musl': 4.60.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.2
+      '@rollup/rollup-linux-ppc64-musl': 4.60.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.2
+      '@rollup/rollup-linux-riscv64-musl': 4.60.2
+      '@rollup/rollup-linux-s390x-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-musl': 4.60.2
+      '@rollup/rollup-openbsd-x64': 4.60.2
+      '@rollup/rollup-openharmony-arm64': 4.60.2
+      '@rollup/rollup-win32-arm64-msvc': 4.60.2
+      '@rollup/rollup-win32-ia32-msvc': 4.60.2
+      '@rollup/rollup-win32-x64-gnu': 4.60.2
+      '@rollup/rollup-win32-x64-msvc': 4.60.2
+      fsevents: 2.3.3
+
   rou3@0.8.1: {}
 
   router@2.2.0:
@@ -6276,6 +6981,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   slice-ansi@4.0.0:
@@ -6319,7 +7026,11 @@ snapshots:
 
   srvx@0.11.15: {}
 
+  stackback@0.0.2: {}
+
   statuses@2.0.2: {}
+
+  std-env@3.10.0: {}
 
   string-width@4.2.3:
     dependencies:
@@ -6554,10 +7265,20 @@ snapshots:
       - '@cfworker/json-schema'
       - supports-color
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -6737,6 +7458,35 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite-node@2.1.9(@types/node@22.19.17)(lightningcss@1.32.0)(terser@5.44.1):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@22.19.17)(lightningcss@1.32.0)(terser@5.44.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(@types/node@22.19.17)(lightningcss@1.32.0)(terser@5.44.1):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.13
+      rollup: 4.60.2
+    optionalDependencies:
+      '@types/node': 22.19.17
+      fsevents: 2.3.3
+      lightningcss: 1.32.0
+      terser: 5.44.1
+
   vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0):
     dependencies:
       lightningcss: 1.32.0
@@ -6756,6 +7506,41 @@ snapshots:
     optionalDependencies:
       vite: 8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)
 
+  vitest@2.1.9(@types/node@22.19.17)(lightningcss@1.32.0)(terser@5.44.1):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.17)(lightningcss@1.32.0)(terser@5.44.1))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@22.19.17)(lightningcss@1.32.0)(terser@5.44.1)
+      vite-node: 2.1.9(@types/node@22.19.17)(lightningcss@1.32.0)(terser@5.44.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.17
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   web-namespaces@1.1.4: {}
 
   web-namespaces@2.0.1: {}
@@ -6771,6 +7556,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/scripts/sync-cosense.test.ts
+++ b/scripts/sync-cosense.test.ts
@@ -1,0 +1,84 @@
+// scripts/sync-cosense.test.ts
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs"
+import { mkdir } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { afterEach, beforeEach, expect, test, vi } from "vitest"
+import { runSync } from "./sync-cosense"
+
+const listJson = JSON.parse(
+  readFileSync(resolve(__dirname, "../lib/sync/__fixtures__/pages-list.json"), "utf8"),
+)
+const detailJson = JSON.parse(
+  readFileSync(resolve(__dirname, "../lib/sync/__fixtures__/page-detail.json"), "utf8"),
+)
+
+let root: string
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "sync-int-"))
+})
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true })
+})
+
+const stubClient = (detail = detailJson) => ({
+  listPages: vi.fn().mockResolvedValue(listJson),
+  getPage: vi.fn().mockResolvedValue(detail),
+})
+
+test("dry-run produces a plan without touching disk", async () => {
+  const c = stubClient()
+  const r = await runSync({
+    client: c,
+    postsRoot: join(root, "posts"),
+    redirectsPath: join(root, "_redirects"),
+    seed: [],
+    maxDeleteRatio: 0.5,
+    dryRun: true,
+  })
+  expect(r.plan.actions.map((a) => a.kind).sort()).toEqual(["create", "create"])
+  expect(c.getPage).not.toHaveBeenCalled()
+  expect(readdirSync(root)).toEqual([])
+})
+
+test("real run creates post directories", async () => {
+  const c = stubClient()
+  const fetchStub = vi.fn().mockResolvedValue(
+    new Response(new Uint8Array([1]), { status: 200 }),
+  )
+  await mkdir(join(root, "posts"), { recursive: true })
+  await runSync({
+    client: c,
+    postsRoot: join(root, "posts"),
+    redirectsPath: join(root, "_redirects"),
+    seed: [],
+    maxDeleteRatio: 0.5,
+    dryRun: false,
+    fetch: fetchStub,
+  })
+  const id = listJson.pages[0].id
+  expect(readFileSync(join(root, "posts", id, "index.md"), "utf8")).toContain(`path: /${id}`)
+})
+
+test("aborts when deletes exceed ratio", async () => {
+  await mkdir(join(root, "posts", "deadbeefdeadbeefdeadbeef"), { recursive: true })
+  writeFileSync(
+    join(root, "posts", "deadbeefdeadbeefdeadbeef", "index.md"),
+    `---\nupdated_at: '2026-01-01T00:00:00.000Z'\n---\n`,
+  )
+  await mkdir(join(root, "posts", "cafebabecafebabecafebabe"), { recursive: true })
+  writeFileSync(
+    join(root, "posts", "cafebabecafebabecafebabe", "index.md"),
+    `---\nupdated_at: '2026-01-01T00:00:00.000Z'\n---\n`,
+  )
+  await expect(
+    runSync({
+      client: stubClient(),
+      postsRoot: join(root, "posts"),
+      redirectsPath: join(root, "_redirects"),
+      seed: [],
+      maxDeleteRatio: 0.5,
+      dryRun: false,
+    }),
+  ).rejects.toThrow(/would delete/)
+})

--- a/scripts/sync-cosense.test.ts
+++ b/scripts/sync-cosense.test.ts
@@ -1,5 +1,12 @@
 // scripts/sync-cosense.test.ts
-import { mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs"
+import {
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs"
 import { mkdir } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
@@ -7,10 +14,16 @@ import { afterEach, beforeEach, expect, test, vi } from "vitest"
 import { runSync } from "./sync-cosense"
 
 const listJson = JSON.parse(
-  readFileSync(resolve(__dirname, "../lib/sync/__fixtures__/pages-list.json"), "utf8"),
+  readFileSync(
+    resolve(__dirname, "../lib/sync/__fixtures__/pages-list.json"),
+    "utf8",
+  ),
 )
 const detailJson = JSON.parse(
-  readFileSync(resolve(__dirname, "../lib/sync/__fixtures__/page-detail.json"), "utf8"),
+  readFileSync(
+    resolve(__dirname, "../lib/sync/__fixtures__/page-detail.json"),
+    "utf8",
+  ),
 )
 
 let root: string
@@ -24,13 +37,13 @@ afterEach(() => {
 const stubClient = () => ({
   listPages: vi.fn().mockResolvedValue(listJson),
   getPage: vi.fn().mockImplementation((title: string) => {
-    const page = listJson.pages.find((p: { title: string }) => p.title === title)
+    const page = listJson.pages.find(
+      (p: { title: string }) => p.title === title,
+    )
     // Return a full page detail whose id matches the list entry so each post
     // lands in its own directory on disk. Fall back to the fixture for unknown titles.
     return Promise.resolve(
-      page
-        ? { ...detailJson, id: page.id, title: page.title }
-        : detailJson,
+      page ? { ...detailJson, id: page.id, title: page.title } : detailJson,
     )
   }),
 })
@@ -52,9 +65,9 @@ test("dry-run produces a plan without touching disk", async () => {
 
 test("real run creates post directories and is idempotent", async () => {
   const c1 = stubClient()
-  const fetchStub = vi.fn().mockResolvedValue(
-    new Response(new Uint8Array([1]), { status: 200 }),
-  )
+  const fetchStub = vi
+    .fn()
+    .mockResolvedValue(new Response(new Uint8Array([1]), { status: 200 }))
   await mkdir(join(root, "posts"), { recursive: true })
 
   await runSync({
@@ -93,12 +106,16 @@ test("real run creates post directories and is idempotent", async () => {
 })
 
 test("aborts when deletes exceed ratio", async () => {
-  await mkdir(join(root, "posts", "deadbeefdeadbeefdeadbeef"), { recursive: true })
+  await mkdir(join(root, "posts", "deadbeefdeadbeefdeadbeef"), {
+    recursive: true,
+  })
   writeFileSync(
     join(root, "posts", "deadbeefdeadbeefdeadbeef", "index.md"),
     `---\nupdated_at: '2026-01-01T00:00:00.000Z'\n---\n`,
   )
-  await mkdir(join(root, "posts", "cafebabecafebabecafebabe"), { recursive: true })
+  await mkdir(join(root, "posts", "cafebabecafebabecafebabe"), {
+    recursive: true,
+  })
   writeFileSync(
     join(root, "posts", "cafebabecafebabecafebabe", "index.md"),
     `---\nupdated_at: '2026-01-01T00:00:00.000Z'\n---\n`,

--- a/scripts/sync-cosense.test.ts
+++ b/scripts/sync-cosense.test.ts
@@ -1,5 +1,5 @@
 // scripts/sync-cosense.test.ts
-import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs"
+import { mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs"
 import { mkdir } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
@@ -21,9 +21,18 @@ afterEach(() => {
   rmSync(root, { recursive: true, force: true })
 })
 
-const stubClient = (detail = detailJson) => ({
+const stubClient = () => ({
   listPages: vi.fn().mockResolvedValue(listJson),
-  getPage: vi.fn().mockResolvedValue(detail),
+  getPage: vi.fn().mockImplementation((title: string) => {
+    const page = listJson.pages.find((p: { title: string }) => p.title === title)
+    // Return a full page detail whose id matches the list entry so each post
+    // lands in its own directory on disk. Fall back to the fixture for unknown titles.
+    return Promise.resolve(
+      page
+        ? { ...detailJson, id: page.id, title: page.title }
+        : detailJson,
+    )
+  }),
 })
 
 test("dry-run produces a plan without touching disk", async () => {
@@ -41,14 +50,15 @@ test("dry-run produces a plan without touching disk", async () => {
   expect(readdirSync(root)).toEqual([])
 })
 
-test("real run creates post directories", async () => {
-  const c = stubClient()
+test("real run creates post directories and is idempotent", async () => {
+  const c1 = stubClient()
   const fetchStub = vi.fn().mockResolvedValue(
     new Response(new Uint8Array([1]), { status: 200 }),
   )
   await mkdir(join(root, "posts"), { recursive: true })
+
   await runSync({
-    client: c,
+    client: c1,
     postsRoot: join(root, "posts"),
     redirectsPath: join(root, "_redirects"),
     seed: [],
@@ -57,7 +67,29 @@ test("real run creates post directories", async () => {
     fetch: fetchStub,
   })
   const id = listJson.pages[0].id
-  expect(readFileSync(join(root, "posts", id, "index.md"), "utf8")).toContain(`path: /${id}`)
+  const dest = join(root, "posts", id, "index.md")
+  expect(readFileSync(dest, "utf8")).toContain(`path: /${id}`)
+  const mtime1 = statSync(dest).mtimeMs
+  const getPageCallsAfterFirst = c1.getPage.mock.calls.length
+
+  // Second run with a fresh stub (mtime check below is the actual idempotency proof).
+  await new Promise((r) => setTimeout(r, 20))
+  const c2 = stubClient()
+  await runSync({
+    client: c2,
+    postsRoot: join(root, "posts"),
+    redirectsPath: join(root, "_redirects"),
+    seed: [],
+    maxDeleteRatio: 0.5,
+    dryRun: false,
+    fetch: fetchStub,
+  })
+  // No second-run getPage calls because both pages are now "unchanged".
+  expect(c2.getPage).not.toHaveBeenCalled()
+  // Initial run did call getPage twice (once per fixture page).
+  expect(getPageCallsAfterFirst).toBe(listJson.pages.length)
+  // mtime unchanged — fs-writer.writePost short-circuited the no-op.
+  expect(statSync(dest).mtimeMs).toBe(mtime1)
 })
 
 test("aborts when deletes exceed ratio", async () => {

--- a/scripts/sync-cosense.ts
+++ b/scripts/sync-cosense.ts
@@ -1,0 +1,109 @@
+// scripts/sync-cosense.ts
+import { mkdir, readdir, readFile, writeFile } from "node:fs/promises"
+import { join, resolve } from "node:path"
+import matter from "gray-matter"
+import { z } from "zod"
+import { CosenseClient } from "@/lib/sync/cosense-client"
+import { computePlan, type LocalPostState } from "@/lib/sync/diff"
+import { deletePost, writePost } from "@/lib/sync/fs-writer"
+import { downloadImages } from "@/lib/sync/images"
+import { emitRedirects, type RedirectSeedEntry } from "@/lib/sync/redirects"
+import { transformPage } from "@/lib/sync/transform"
+
+const envSchema = z.object({
+  COSENSE_PROJECT: z.string().min(1),
+  COSENSE_SID: z.string().min(1),
+  MAX_DELETE_RATIO: z.coerce.number().min(0).max(1).default(0.5),
+})
+
+const POSTS_ROOT = resolve(process.cwd(), "content/posts")
+const REDIRECTS_PATH = resolve(process.cwd(), "public/_redirects")
+const SEED_PATH = resolve(process.cwd(), "lib/sync/redirects-seed.json")
+
+interface Args {
+  dryRun: boolean
+}
+
+function parseArgs(argv: string[]): Args {
+  return {
+    dryRun:
+      argv.includes("--dry-run") || process.env.SYNC_DRY_RUN === "true",
+  }
+}
+
+async function readLocalState(): Promise<LocalPostState[]> {
+  let entries: string[]
+  try {
+    entries = await readdir(POSTS_ROOT)
+  } catch {
+    return []
+  }
+  const out: LocalPostState[] = []
+  for (const id of entries) {
+    if (!/^[a-f0-9]{24}$/.test(id)) continue
+    const front = matter(
+      await readFile(join(POSTS_ROOT, id, "index.md"), "utf8"),
+    ).data
+    if (typeof front.updated_at !== "string") continue
+    out.push({ id, updatedAt: new Date(front.updated_at) })
+  }
+  return out
+}
+
+async function readSeed(): Promise<RedirectSeedEntry[]> {
+  try {
+    return JSON.parse(await readFile(SEED_PATH, "utf8"))
+  } catch {
+    return []
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+  const env = envSchema.parse(process.env)
+
+  const client = new CosenseClient({
+    project: env.COSENSE_PROJECT,
+    sid: env.COSENSE_SID,
+  })
+  const list = await client.listPages()
+  const local = await readLocalState()
+  const plan = computePlan(list.pages, local)
+
+  const deletions = plan.actions.filter((a) => a.kind === "delete").length
+  if (plan.localCount > 0 && deletions / plan.localCount > env.MAX_DELETE_RATIO) {
+    throw new Error(`abort: would delete ${deletions}/${plan.localCount} posts`)
+  }
+
+  console.log(`plan: ${plan.actions.map((a) => a.kind).join(",")}`)
+
+  if (args.dryRun) {
+    await writeFile(
+      resolve(process.cwd(), ".sync-plan.json"),
+      JSON.stringify(plan, null, 2),
+    )
+    return
+  }
+
+  for (const action of plan.actions) {
+    if (action.kind === "delete") {
+      await deletePost(action.id, POSTS_ROOT)
+      continue
+    }
+    if (action.kind === "unchanged") continue
+    const page = await client.getPage(action.page.title)
+    const post = transformPage(page)
+    const postDir = join(POSTS_ROOT, post.id)
+    await mkdir(postDir, { recursive: true })
+    await downloadImages(post.images, postDir)
+    await writePost(post, POSTS_ROOT)
+  }
+
+  const redirects = emitRedirects(await readSeed())
+  if (redirects.length > 0) await writeFile(REDIRECTS_PATH, redirects)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/scripts/sync-cosense.ts
+++ b/scripts/sync-cosense.ts
@@ -1,7 +1,6 @@
 // scripts/sync-cosense.ts
 import { mkdir, readdir, readFile, writeFile } from "node:fs/promises"
 import { join, resolve } from "node:path"
-import matter from "gray-matter"
 import { z } from "zod"
 import { CosenseClient } from "@/lib/sync/cosense-client"
 import { computePlan, type LocalPostState } from "@/lib/sync/diff"
@@ -31,25 +30,6 @@ function parseArgs(argv: string[]): Args {
   }
 }
 
-async function readLocalState(): Promise<LocalPostState[]> {
-  let entries: string[]
-  try {
-    entries = await readdir(POSTS_ROOT)
-  } catch {
-    return []
-  }
-  const out: LocalPostState[] = []
-  for (const id of entries) {
-    if (!/^[a-f0-9]{24}$/.test(id)) continue
-    const front = matter(
-      await readFile(join(POSTS_ROOT, id, "index.md"), "utf8"),
-    ).data
-    if (typeof front.updated_at !== "string") continue
-    out.push({ id, updatedAt: new Date(front.updated_at) })
-  }
-  return out
-}
-
 async function readSeed(): Promise<RedirectSeedEntry[]> {
   try {
     return JSON.parse(await readFile(SEED_PATH, "utf8"))
@@ -58,52 +38,91 @@ async function readSeed(): Promise<RedirectSeedEntry[]> {
   }
 }
 
-async function main() {
-  const args = parseArgs(process.argv.slice(2))
-  const env = envSchema.parse(process.env)
+export interface RunOptions {
+  client: Pick<CosenseClient, "listPages" | "getPage">
+  postsRoot: string
+  redirectsPath: string
+  seed: RedirectSeedEntry[]
+  maxDeleteRatio: number
+  dryRun: boolean
+  fetch?: typeof globalThis.fetch
+}
 
-  const client = new CosenseClient({
-    project: env.COSENSE_PROJECT,
-    sid: env.COSENSE_SID,
-  })
-  const list = await client.listPages()
-  const local = await readLocalState()
+export async function runSync(
+  opts: RunOptions,
+): Promise<{ plan: ReturnType<typeof computePlan> }> {
+  const list = await opts.client.listPages()
+  const local = await readLocalStateAt(opts.postsRoot)
   const plan = computePlan(list.pages, local)
 
   const deletions = plan.actions.filter((a) => a.kind === "delete").length
-  if (plan.localCount > 0 && deletions / plan.localCount > env.MAX_DELETE_RATIO) {
+  if (plan.localCount > 0 && deletions / plan.localCount > opts.maxDeleteRatio) {
     throw new Error(`abort: would delete ${deletions}/${plan.localCount} posts`)
   }
 
-  console.log(`plan: ${plan.actions.map((a) => a.kind).join(",")}`)
-
-  if (args.dryRun) {
-    await writeFile(
-      resolve(process.cwd(), ".sync-plan.json"),
-      JSON.stringify(plan, null, 2),
-    )
-    return
-  }
+  if (opts.dryRun) return { plan }
 
   for (const action of plan.actions) {
     if (action.kind === "delete") {
-      await deletePost(action.id, POSTS_ROOT)
+      await deletePost(action.id, opts.postsRoot)
       continue
     }
     if (action.kind === "unchanged") continue
-    const page = await client.getPage(action.page.title)
+    const page = await opts.client.getPage(action.page.title)
     const post = transformPage(page)
-    const postDir = join(POSTS_ROOT, post.id)
+    const postDir = join(opts.postsRoot, post.id)
     await mkdir(postDir, { recursive: true })
-    await downloadImages(post.images, postDir)
-    await writePost(post, POSTS_ROOT)
+    await downloadImages(post.images, postDir, { fetch: opts.fetch })
+    await writePost(post, opts.postsRoot)
   }
 
-  const redirects = emitRedirects(await readSeed())
-  if (redirects.length > 0) await writeFile(REDIRECTS_PATH, redirects)
+  const redirects = emitRedirects(opts.seed)
+  if (redirects.length > 0) await writeFile(opts.redirectsPath, redirects)
+  return { plan }
 }
 
-main().catch((err) => {
-  console.error(err)
-  process.exit(1)
-})
+const UPDATED_AT_RE = /^updated_at:\s*'([^']+)'/m
+
+async function readLocalStateAt(postsRoot: string): Promise<LocalPostState[]> {
+  let entries: string[]
+  try {
+    entries = await readdir(postsRoot)
+  } catch {
+    return []
+  }
+  const out: LocalPostState[] = []
+  for (const id of entries) {
+    if (!/^[a-f0-9]{24}$/.test(id)) continue
+    const text = await readFile(join(postsRoot, id, "index.md"), "utf8")
+    const m = UPDATED_AT_RE.exec(text)
+    if (!m) continue
+    out.push({ id, updatedAt: new Date(m[1]) })
+  }
+  return out
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    const args = parseArgs(process.argv.slice(2))
+    const env = envSchema.parse(process.env)
+    const seed = await readSeed()
+    const { plan } = await runSync({
+      client: new CosenseClient({ project: env.COSENSE_PROJECT, sid: env.COSENSE_SID }),
+      postsRoot: POSTS_ROOT,
+      redirectsPath: REDIRECTS_PATH,
+      seed,
+      maxDeleteRatio: env.MAX_DELETE_RATIO,
+      dryRun: args.dryRun,
+    })
+    console.log(`plan: ${plan.actions.map((a) => a.kind).join(",")}`)
+    if (args.dryRun) {
+      await writeFile(
+        resolve(process.cwd(), ".sync-plan.json"),
+        JSON.stringify(plan, null, 2),
+      )
+    }
+  } catch (err) {
+    console.error(err)
+    process.exit(1)
+  }
+}

--- a/scripts/sync-cosense.ts
+++ b/scripts/sync-cosense.ts
@@ -81,6 +81,11 @@ export async function runSync(
   return { plan }
 }
 
+// Coupled to lib/sync/frontmatter.ts:emitFrontmatter — single-quoted ISO
+// string. gray-matter@4 is the obvious tool for this but it calls
+// js-yaml.safeLoad which was removed in js-yaml@4 (and the repo overrides
+// js-yaml to >=4.x). Do not switch to gray-matter without first pinning
+// js-yaml to ^3.x.
 const UPDATED_AT_RE = /^updated_at:\s*'([^']+)'/m
 
 async function readLocalStateAt(postsRoot: string): Promise<LocalPostState[]> {
@@ -102,27 +107,33 @@ async function readLocalStateAt(postsRoot: string): Promise<LocalPostState[]> {
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  try {
-    const args = parseArgs(process.argv.slice(2))
-    const env = envSchema.parse(process.env)
-    const seed = await readSeed()
-    const { plan } = await runSync({
-      client: new CosenseClient({ project: env.COSENSE_PROJECT, sid: env.COSENSE_SID }),
-      postsRoot: POSTS_ROOT,
-      redirectsPath: REDIRECTS_PATH,
-      seed,
-      maxDeleteRatio: env.MAX_DELETE_RATIO,
-      dryRun: args.dryRun,
+  const args = parseArgs(process.argv.slice(2))
+  const env = envSchema.parse(process.env)
+  readSeed()
+    .then((seed) =>
+      runSync({
+        client: new CosenseClient({
+          project: env.COSENSE_PROJECT,
+          sid: env.COSENSE_SID,
+        }),
+        postsRoot: POSTS_ROOT,
+        redirectsPath: REDIRECTS_PATH,
+        seed,
+        maxDeleteRatio: env.MAX_DELETE_RATIO,
+        dryRun: args.dryRun,
+      }),
+    )
+    .then(async ({ plan }) => {
+      console.log(`plan: ${plan.actions.map((a) => a.kind).join(",")}`)
+      if (args.dryRun) {
+        await writeFile(
+          resolve(process.cwd(), ".sync-plan.json"),
+          JSON.stringify(plan, null, 2),
+        )
+      }
     })
-    console.log(`plan: ${plan.actions.map((a) => a.kind).join(",")}`)
-    if (args.dryRun) {
-      await writeFile(
-        resolve(process.cwd(), ".sync-plan.json"),
-        JSON.stringify(plan, null, 2),
-      )
-    }
-  } catch (err) {
-    console.error(err)
-    process.exit(1)
-  }
+    .catch((err) => {
+      console.error(err)
+      process.exit(1)
+    })
 }

--- a/scripts/sync-cosense.ts
+++ b/scripts/sync-cosense.ts
@@ -25,8 +25,7 @@ interface Args {
 
 function parseArgs(argv: string[]): Args {
   return {
-    dryRun:
-      argv.includes("--dry-run") || process.env.SYNC_DRY_RUN === "true",
+    dryRun: argv.includes("--dry-run") || process.env.SYNC_DRY_RUN === "true",
   }
 }
 
@@ -56,7 +55,10 @@ export async function runSync(
   const plan = computePlan(list.pages, local)
 
   const deletions = plan.actions.filter((a) => a.kind === "delete").length
-  if (plan.localCount > 0 && deletions / plan.localCount > opts.maxDeleteRatio) {
+  if (
+    plan.localCount > 0 &&
+    deletions / plan.localCount > opts.maxDeleteRatio
+  ) {
     throw new Error(`abort: would delete ${deletions}/${plan.localCount} posts`)
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,7 @@
     "scripts/**/*.ts",
     "styles/**/*.ts",
     "styles/**/*.tsx",
+    "vitest.config.ts",
     "vite.config.mts"
   ],
   "exclude": [

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    include: ["lib/**/*.test.ts", "scripts/**/*.test.ts"],
+    environment: "node",
+    reporters: "default",
+    pool: "forks",
+  },
+  resolve: {
+    alias: { "@": new URL(".", import.meta.url).pathname.replace(/\/$/, "") },
+  },
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from "node:url"
 import { defineConfig } from "vitest/config"
 
 export default defineConfig({
@@ -8,6 +9,8 @@ export default defineConfig({
     pool: "forks",
   },
   resolve: {
-    alias: { "@": new URL(".", import.meta.url).pathname.replace(/\/$/, "") },
+    alias: {
+      "@": fileURLToPath(new URL(".", import.meta.url)).replace(/[\\/]$/, ""),
+    },
   },
 })


### PR DESCRIPTION
## Summary

- Phase 1 of the Cosense → blog source-of-truth migration. Introduces a one-way pull pipeline (Cosense → `content/posts/<page-id>/index.md`) without touching the existing Velite + TanStack Start build. Workflow is `workflow_dispatch` only; no cron, no production data, no migration in this PR.
- Adds `lib/sync/*` (10 modules: types, cosense-client, scrapbox-to-md, transform, frontmatter, slug, images, fs-writer, redirects, diff) + `scripts/sync-cosense.ts` orchestrator + `.github/workflows/sync.yml`. 56 unit tests across 10 test files.
- Includes the Phase 1 design spec (`docs/superpowers/specs/2026-05-04-cosense-source-of-truth-design.md`) and the implementation plan (`docs/superpowers/plans/2026-05-04-cosense-sync-phase-1.md`). Plan was kept in sync with code through 14 task commits + per-task review fix commits.
- **Also includes a revised Phase 2 spec** (`docs/superpowers/specs/2026-05-04-cosense-phase-2-design.md`) that supersedes the Phase 1 spec's source-of-truth assumption — see "Phase 2 spec rewrite" below for why.

## What does NOT change in this PR

- No edits to `app/`, `components/`, `styles/`, `velite.config.ts`, `vite.config.mts`, or any existing post under `content/posts/`.
- No deps removed; adds `vitest` (devDep) and `zod` (dep). Existing `pnpm test` (tsc) remains the type-check gate; new `pnpm test:unit` runs vitest. Existing CI's test job grows by one `pnpm test:unit` step.

## Phase 1 deliberate deviations from its own spec (Phase 2 follow-ups)

- **Pagination is asserted, not implemented.** Aborts loudly if a Cosense project exceeds 1000 pages (`lib/sync/cosense-client.ts:35-39`). Phase 2 must add `skip`-loop pagination before enabling cron.
- **Per-page error tolerance deferred.** Current orchestrator throws on the first per-page failure. Acceptable while triggering is `workflow_dispatch` only. Phase 2 must add `.sync-errors.json` and "skip page, continue" before cron.
- **Pre-write `postSchema` validation deferred.** Relies on `pnpm build` to catch schema drift. Acceptable for Phase 1.
- **`gray-matter` swapped for a regex.** `gray-matter@4` calls `js-yaml.safeLoad`, which was removed in `js-yaml@4` (the project pins `js-yaml@>=4.1.1` via `pnpm.overrides`). The orchestrator parses local `updated_at:` lines with `UPDATED_AT_RE` instead. See the comment above the regex in `scripts/sync-cosense.ts`.

## Phase 2 spec rewrite (why the new file is in this PR)

Phase 1 acceptance dry-run against the real Cosense project surfaced an unexpected reality:

- The Cosense project has **51 pages**, not all of which are blog content.
- **48 of those 51 already exist as blog posts** (manually copied since 2019).
- 3 are new (the author plans to publish them after creating blog stubs).
- 61 blog posts have no Cosense counterpart.

Phase 1's "every Cosense page becomes a blog post at `/<page-id>/`" model would, if run today, create 48 duplicate URLs and silently publish drafts. The Phase 2 spec replaces it with **"a blog post stub is the publishing decision; Cosense provides the content"**. Sync now matches by title (and `cosense_id` once stamped), preserves existing URLs, and skips pages with no stub. See the Phase 2 spec for full rationale.

## Production risk if `gh workflow run sync.yml --field dry_run=false` is triggered today (Phase 1 only — DO NOT)

51 actions all classified as `create` would land 48 duplicate posts under `/<page-id>/` URLs alongside the existing canonical URLs. **Don't trigger non-dry-run until Phase 2 lands.** The 50% delete safety net would not engage because `localCount === 0` (existing date-prefix slugs are invisible to the page-id matcher).

## Branch note

This branch is named `docs/cosense-source-of-truth-spec` because it was created when the original (Phase 1) spec was first committed. It now carries the Phase 1 spec, the Phase 1 plan, the Phase 1 implementation, and the Phase 2 spec. Squashing into a single feat commit on merge would lose the per-task / per-review history; rebase-and-merge preserves it.

## Test plan

- [x] `pnpm lint:ci` passes
- [x] `pnpm test` (tsc) passes
- [x] `pnpm test:unit` 56/56 green across 10 files
- [x] `pnpm build` (Velite + Vite + TanStack Start prerender) succeeds
- [x] `pnpm sync` (no env) fails fast with a zod validation error (no top-level-await regression, no transform crash)
- [x] `pnpm sync --dry-run` against the real Cosense project produces a 51-action plan (this is what surfaced the duplicate-publish risk and motivated the Phase 2 spec rewrite)
- [ ] After merge: secrets `COSENSE_PROJECT` and `COSENSE_SID` are already set in repo settings (placeholder SID is fine for the public project)
- [ ] After merge: do NOT trigger `dry_run: false` until Phase 2 ships
- [ ] Next: open Phase 2 implementation PR per the spec at `docs/superpowers/specs/2026-05-04-cosense-phase-2-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)