### PR TITLE
Phase 4: auto-publish + delete propagation for Cosense sync

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -29,8 +29,10 @@ jobs:
         continue-on-error: true
         run: pnpm sync ${{ inputs.dry_run && '--dry-run' || '' }}
         env:
-          COSENSE_PROJECT: ${{ secrets.COSENSE_PROJECT }}
-          COSENSE_SID:     ${{ secrets.COSENSE_SID }}
+          COSENSE_PROJECT:  ${{ secrets.COSENSE_PROJECT }}
+          COSENSE_SID:      ${{ secrets.COSENSE_SID }}
+          MAX_DELETE_ABS:   '5'
+          MAX_DELETE_RATIO: '0.05'
       - name: Commit & push (skipped on dry-run)
         if: ${{ !inputs.dry_run }}
         run: |

--- a/docs/superpowers/plans/2026-05-04-cosense-sync-phase-4.md
+++ b/docs/superpowers/plans/2026-05-04-cosense-sync-phase-4.md
@@ -1,0 +1,1240 @@
+# Cosense sync — Phase 4 (auto-publish + delete propagation) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Cosense the source of truth for any blog post that has a `cosense_id`: auto-create stubs when new Cosense pages appear, auto-delete stubs when their Cosense page disappears, while leaving 61 legacy posts (without `cosense_id`) untouched and guarding against catastrophic Cosense API states with a two-threshold delete cap.
+
+**Architecture:** Reverse two of Phase 2's deliberate restrictions in the diff stage — re-add `create` and `delete` to `SyncAction`, drop `skip`. Add `slugForTitle` to derive URLs from titles (page-id fallback for non-ASCII). Add `createPost` / `deletePost` to `fs-writer`. Read `MAX_DELETE_ABS` and `MAX_DELETE_RATIO` env vars in the orchestrator and throw `DeleteThresholdError` (caught by Phase 3's existing health-reporter path) before any deletes execute when either threshold is exceeded.
+
+**Tech Stack:** TypeScript 5.9, vitest, zod, tsx, pnpm 9, GitHub Actions.
+
+**Spec:** `docs/superpowers/specs/2026-05-04-cosense-phase-4-design.md`.
+
+**Branch:** `feat/cosense-sync-phase-4`, already created from `origin/main`.
+
+---
+
+## File Structure
+
+**Modified:**
+
+- `lib/sync/slug.ts` — add `slugForTitle(title, pageId)`. Existing `slugForPageId` and `isValidSlug` untouched.
+- `lib/sync/slug.test.ts` — append tests for `slugForTitle`.
+- `lib/sync/types.ts` — replace `SyncAction` union (drop `skip`, add `create` and `delete`); add `DeleteThresholdError` class.
+- `lib/sync/diff.ts` — emit `create` for unmatched remote pages, `delete` for stubs whose `cosenseId` is no longer in remote, drop `skip` branch.
+- `lib/sync/diff.test.ts` — rewrite test suite: replace `skip`-based cases with `create`-based cases, add `delete` cases.
+- `lib/sync/fs-writer.ts` — add `createPost(post, blogDir)` and `deletePost(blogDir)`. Existing `updatePost` and `FrontmatterParseError` untouched.
+- `lib/sync/fs-writer.test.ts` — append `createPost` and `deletePost` test blocks.
+- `scripts/sync-cosense.ts` — read `MAX_DELETE_ABS` (default 5) and `MAX_DELETE_RATIO` (default 0.05); compute delete count and ratio; throw `DeleteThresholdError` before applying any actions if either threshold is violated; dispatch `create` and `delete` actions inside the existing per-page `try/catch`; resolve slug collisions at apply time.
+- `scripts/sync-cosense.test.ts` — append integration scenarios for create, delete, threshold violation, and slug collision.
+- `.github/workflows/sync.yml` — add `MAX_DELETE_ABS: 5` and `MAX_DELETE_RATIO: '0.05'` to the `Run sync` step's `env:` block. Documented as configurable.
+
+**Untouched:**
+
+- `scripts/sync-report-health.ts` and its tests (Phase 3) — the reporter only reads `SYNC_STATUS` and `.sync-errors.json`; nothing here changes.
+- `lib/sync/cosense-client.ts`, `transform.ts`, `scrapbox-to-md.ts`, `parse-frontmatter.ts`, `images.ts`.
+- `app/`, `components/`, `styles/`, `velite.config.ts`, `tsconfig.json`, `vitest.config.ts`, `package.json`.
+- `content/posts/**` (sync will modify these at runtime, but no static edits land in this branch).
+
+**Notes on intermediate-state breakage:** Task 2 leaves `lib/sync/diff.ts` type-failing because the `skip` variant it emits is no longer part of the `SyncAction` union. `scripts/sync-cosense.ts` happens to remain type-clean during this window (it only narrows on `kind: "update"` and generic-counts the rest), but the new `create` and `delete` actions are silently no-ops at runtime until Task 5 wires them up. Full type-clean is restored at the end of Task 4; full functional correctness at the end of Task 5. Per-task verification gates in Tasks 2 and 3 explicitly only check the touched module's tests via `pnpm test:unit <file>` to avoid noise from the broken `diff.ts`.
+
+---
+
+## Task 1: `slugForTitle` in `lib/sync/slug.ts`
+
+**Files:**
+- Modify: `lib/sync/slug.ts` (append a new export)
+- Modify: `lib/sync/slug.test.ts` (append tests)
+
+This task adds a pure title-to-slug function with a page-id fallback. It has no dependencies on the type changes in later tasks and ships independently green.
+
+- [ ] **Step 1: Append failing tests for `slugForTitle`**
+
+Open `lib/sync/slug.test.ts`. Replace the existing top-of-file imports with:
+
+```ts
+import { expect, test } from "vitest"
+import { isValidSlug, slugForPageId, slugForTitle } from "./slug"
+```
+
+Then append these tests after the existing ones:
+
+```ts
+test("slugForTitle: ASCII title becomes lowercase kebab-case", () => {
+  expect(slugForTitle("Awesome Feature", "0123456789abcdef01234567")).toBe(
+    "awesome-feature",
+  )
+})
+
+test("slugForTitle: collapses runs of whitespace and dashes", () => {
+  expect(
+    slugForTitle("Hello   World---thing", "0123456789abcdef01234567"),
+  ).toBe("hello-world-thing")
+})
+
+test("slugForTitle: strips punctuation that is not a dash", () => {
+  expect(
+    slugForTitle("Don't break, please!", "0123456789abcdef01234567"),
+  ).toBe("dont-break-please")
+})
+
+test("slugForTitle: trims leading and trailing dashes", () => {
+  expect(slugForTitle("--- foo ---", "0123456789abcdef01234567")).toBe("foo")
+})
+
+test("slugForTitle: pure-CJK title falls back to page id", () => {
+  expect(slugForTitle("買ってよかったもの", "0123456789abcdef01234567")).toBe(
+    "0123456789abcdef01234567",
+  )
+})
+
+test("slugForTitle: title that slugifies to under 3 chars falls back to page id", () => {
+  expect(slugForTitle("a!", "0123456789abcdef01234567")).toBe(
+    "0123456789abcdef01234567",
+  )
+})
+
+test("slugForTitle: numeric-only title is kept when long enough", () => {
+  expect(slugForTitle("2026", "0123456789abcdef01234567")).toBe("2026")
+})
+
+test("slugForTitle: mixed CJK + ASCII keeps the ASCII portion when long enough", () => {
+  expect(
+    slugForTitle("買ってよかったもの 2025 review", "0123456789abcdef01234567"),
+  ).toBe("2025-review")
+})
+
+test("slugForTitle: rejects an invalid page id", () => {
+  expect(() => slugForTitle("Anything", "not-a-page-id")).toThrow(
+    /invalid Cosense page id/,
+  )
+})
+```
+
+- [ ] **Step 2: Run the new tests and confirm they fail**
+
+Run: `pnpm test:unit lib/sync/slug.test.ts`
+
+Expected: failures with `Cannot find name 'slugForTitle'` (TS2304) at compile time, or `slugForTitle is not a function` at runtime.
+
+- [ ] **Step 3: Implement `slugForTitle`**
+
+Open `lib/sync/slug.ts`. Append (after the existing `isValidSlug` function):
+
+```ts
+export function slugForTitle(title: string, pageId: string): string {
+  if (!PAGE_ID_RE.test(pageId)) {
+    throw new Error(`invalid Cosense page id: ${pageId}`)
+  }
+  const slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+  if (slug.length >= 3) return slug
+  return pageId
+}
+```
+
+- [ ] **Step 4: Run the tests and confirm they pass**
+
+Run: `pnpm test:unit lib/sync/slug.test.ts`
+
+Expected: all `slug.test.ts` cases pass (the original 3 plus the 9 new ones = 12).
+
+- [ ] **Step 5: Run typecheck and lint**
+
+Run: `pnpm test && pnpm lint:ci`
+
+Expected: both succeed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/sync/slug.ts lib/sync/slug.test.ts
+git commit -m "slug: add slugForTitle with ASCII slugify + page-id fallback"
+```
+
+---
+
+## Task 2: `SyncAction` union update + `DeleteThresholdError` in `lib/sync/types.ts`
+
+**Files:**
+- Modify: `lib/sync/types.ts`
+
+This task changes the shape of `SyncAction`, which intentionally breaks the consumers (`diff.ts`, `sync-cosense.ts`) until later tasks update them. We commit anyway — Tasks 4 and 5 fix the resulting type errors.
+
+- [ ] **Step 1: Replace the `SyncAction` union**
+
+Open `lib/sync/types.ts`. Find:
+
+```ts
+/** Output of diff stage. */
+export type SyncAction =
+  | { kind: "update"; page: CosenseListEntry; blogDir: string }
+  | { kind: "unchanged"; id: string }
+  | { kind: "skip"; title: string; reason: "no-stub" }
+```
+
+Replace with:
+
+```ts
+/** Output of diff stage. */
+export type SyncAction =
+  | { kind: "create"; page: CosenseListEntry; slug: string }
+  | { kind: "update"; page: CosenseListEntry; blogDir: string }
+  | { kind: "unchanged"; id: string }
+  | { kind: "delete"; blogDir: string; cosenseId: string }
+```
+
+The `slug` on a `create` action is the *preferred* slug from `slugForTitle`. The orchestrator may append a `-<6-hex>` suffix at apply time if `<postsRoot>/<slug>/` already exists; the diff stage does not touch the filesystem.
+
+- [ ] **Step 2: Add `DeleteThresholdError` at the end of the file**
+
+Append to `lib/sync/types.ts`:
+
+```ts
+/**
+ * Thrown by the sync orchestrator when the count or ratio of `delete` actions
+ * in a single run exceeds configured thresholds. Treated as a workflow
+ * crash by Phase 3's health reporter (which opens a `sync-broken` issue).
+ */
+export class DeleteThresholdError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "DeleteThresholdError"
+  }
+}
+```
+
+- [ ] **Step 3: Confirm tsc breaks at the consumer files (expected)**
+
+Run: `pnpm test`
+
+Expected: errors in `lib/sync/diff.ts` and `scripts/sync-cosense.ts` referring to `kind: "skip"` and missing `kind: "create" | "delete"` arms. **Do not fix them in this task.** They are addressed in Tasks 4 and 5.
+
+- [ ] **Step 4: Confirm `lib/sync/types.ts` itself has no type errors**
+
+Run: `npx tsc --noEmit lib/sync/types.ts 2>&1 | grep -E "types\.ts" || echo "types.ts is clean"`
+
+Expected: `types.ts is clean`.
+
+- [ ] **Step 5: Commit (intermediate-state-breaking)**
+
+```bash
+git add lib/sync/types.ts
+git commit -m "sync types: replace skip with create/delete, add DeleteThresholdError"
+```
+
+---
+
+## Task 3: `createPost` and `deletePost` in `lib/sync/fs-writer.ts`
+
+**Files:**
+- Modify: `lib/sync/fs-writer.ts`
+- Modify: `lib/sync/fs-writer.test.ts`
+
+This task adds two file-writer primitives. They are independent of the `SyncAction` type changes and tested in isolation. The existing `updatePost` is untouched.
+
+- [ ] **Step 1: Append failing tests for `createPost`**
+
+Open `lib/sync/fs-writer.test.ts`. Replace the existing import line `import { updatePost } from "./fs-writer"` with:
+
+```ts
+import { createPost, deletePost, updatePost } from "./fs-writer"
+```
+
+Append after the last existing test:
+
+```ts
+test("createPost: writes a fresh index.md with full frontmatter", async () => {
+  const dir = join(root, "antigravity")
+  await mkdir(dir, { recursive: true })
+  await createPost(post, dir)
+  const out = readFileSync(join(dir, "index.md"), "utf8")
+  expect(out).toContain('title: "Sample"')
+  expect(out).toContain("created_at: '2026-05-01T00:00:00.000Z'")
+  expect(out).toContain("updated_at: '2026-05-04T00:00:00.000Z'")
+  expect(out).toContain("cosense_id: 0123456789abcdef01234567")
+  expect(out).toContain("\n\nHello body.\n")
+})
+
+test("createPost: throws when index.md already exists", async () => {
+  const dir = join(root, "antigravity")
+  await mkdir(dir, { recursive: true })
+  writeFileSync(join(dir, "index.md"), "existing")
+  await expect(createPost(post, dir)).rejects.toThrow(/already exists/i)
+})
+
+test("createPost: throws when blogDir does not exist", async () => {
+  const dir = join(root, "missing")
+  await expect(createPost(post, dir)).rejects.toThrow(/ENOENT|no such file/i)
+})
+
+test("createPost: does not leave a .tmp file when the write succeeds", async () => {
+  const dir = join(root, "antigravity")
+  await mkdir(dir, { recursive: true })
+  await createPost(post, dir)
+  expect(() => statSync(join(dir, "index.md.tmp"))).toThrow()
+})
+
+test("createPost: title is JSON-quoted (handles embedded quotes)", async () => {
+  const dir = join(root, "quoted")
+  await mkdir(dir, { recursive: true })
+  const tricky = { ...post, title: 'Has "quotes" and \\backslash' }
+  await createPost(tricky, dir)
+  const out = readFileSync(join(dir, "index.md"), "utf8")
+  expect(out).toContain('title: "Has \\"quotes\\" and \\\\backslash"')
+})
+
+test("deletePost: removes the directory recursively", async () => {
+  const dir = join(root, "to-delete")
+  await mkdir(dir, { recursive: true })
+  writeFileSync(join(dir, "index.md"), "stuff")
+  writeFileSync(join(dir, "image.png"), "binary")
+  await deletePost(dir)
+  expect(() => statSync(dir)).toThrow()
+})
+
+test("deletePost: ENOENT is a no-op (idempotent)", async () => {
+  const dir = join(root, "never-existed")
+  await expect(deletePost(dir)).resolves.toBeUndefined()
+})
+```
+
+- [ ] **Step 2: Run the new tests and confirm they fail**
+
+Run: `pnpm test:unit lib/sync/fs-writer.test.ts`
+
+Expected: failures referring to missing imports `createPost` and `deletePost`.
+
+- [ ] **Step 3: Implement `createPost` and `deletePost`**
+
+Open `lib/sync/fs-writer.ts`. Replace the existing top-of-file imports with:
+
+```ts
+import { access, readFile, rename, rm, unlink, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import type { Post } from "./types"
+```
+
+Append after the existing `updatePost` function (at the bottom of the file):
+
+```ts
+function renderNewIndex(post: Post): string {
+  const fm = [
+    `title: ${JSON.stringify(post.title)}`,
+    `created_at: '${post.createdAt.toISOString()}'`,
+    `updated_at: '${post.updatedAt.toISOString()}'`,
+    `cosense_id: ${post.id}`,
+  ].join("\n")
+  const body = post.body.endsWith("\n") ? post.body : `${post.body}\n`
+  return `---\n${fm}\n---\n\n${body}`
+}
+
+export async function createPost(post: Post, blogDir: string): Promise<void> {
+  // blogDir must already exist (orchestrator's job); ENOENT surfaces
+  // through the writeFile below if it does not.
+  const indexPath = join(blogDir, "index.md")
+  // index.md must NOT exist; throw a clear message if it does.
+  try {
+    await access(indexPath)
+    throw new Error(`index.md already exists at ${indexPath}`)
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err
+  }
+  const tmp = `${indexPath}.tmp`
+  await writeFile(tmp, renderNewIndex(post))
+  try {
+    await rename(tmp, indexPath)
+  } catch (err) {
+    await unlink(tmp).catch(() => {})
+    throw err
+  }
+}
+
+export async function deletePost(blogDir: string): Promise<void> {
+  await rm(blogDir, { recursive: true, force: true })
+}
+```
+
+Two notes on the design:
+- `access(indexPath)` is the cheapest existence check. We deliberately distinguish "index.md already exists" (throw a clear message) from "blogDir does not exist" (let the subsequent `writeFile(tmp, ...)` surface the OS-level ENOENT, which the test asserts via the `/ENOENT|no such file/i` regex).
+- `mkdir` is intentionally NOT called inside `createPost`. The orchestrator creates the directory as a separate step so it can roll back the directory cleanly if any subsequent step (image download, write) fails — see Task 5.
+
+- [ ] **Step 4: Run the tests and confirm they pass**
+
+Run: `pnpm test:unit lib/sync/fs-writer.test.ts`
+
+Expected: all 13 tests pass (6 pre-existing for `updatePost` + 5 new for `createPost` + 2 new for `deletePost`).
+
+- [ ] **Step 5: Run lint**
+
+Run: `pnpm lint:ci`
+
+Expected: pass. (Skip `pnpm test` (tsc) for now — `diff.ts` and `sync-cosense.ts` still emit pre-existing errors from Task 2.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/sync/fs-writer.ts lib/sync/fs-writer.test.ts
+git commit -m "fs-writer: add createPost (atomic) and deletePost (idempotent rm)"
+```
+
+---
+
+## Task 4: `lib/sync/diff.ts` rewrite
+
+**Files:**
+- Modify: `lib/sync/diff.ts`
+- Modify: `lib/sync/diff.test.ts`
+
+This task replaces `skip` emission with `create` and adds `delete` emission for stubs whose `cosenseId` is no longer in the remote list. Stubs without `cosenseId` are completely invisible to the delete pass.
+
+- [ ] **Step 1: Rewrite the test suite**
+
+Open `lib/sync/diff.test.ts` and replace its **entire** contents with:
+
+```ts
+import { describe, expect, test } from "vitest"
+import { computePlan, type LocalPostState } from "./diff"
+import type { CosenseListEntry } from "./types"
+
+const remote: CosenseListEntry[] = [
+  { id: "0123456789abcdef01234567", title: "A", updated: 1000 },
+  { id: "fedcba9876543210fedcba98", title: "B", updated: 2000 },
+]
+
+describe("computePlan", () => {
+  test("no stubs: every remote page becomes a create with a slug from title", () => {
+    const plan = computePlan(remote, [])
+    expect(plan.actions.map((a) => a.kind).sort()).toEqual(["create", "create"])
+    const a = plan.actions.find(
+      (act) => act.kind === "create" && act.page.title === "A",
+    )
+    if (!a || a.kind !== "create") throw new Error("expected a create for A")
+    expect(a.slug).toBe("a") // length-2 slug falls back to page id
+    // length-1 was the actual concern; "a" is length-1 → falls back
+  })
+
+  test("create with a long-enough ASCII title uses the slug as-is", () => {
+    const single: CosenseListEntry[] = [
+      {
+        id: "0123456789abcdef01234567",
+        title: "Antigravity",
+        updated: 1000,
+      },
+    ]
+    const plan = computePlan(single, [])
+    const c = plan.actions[0]
+    expect(c.kind).toBe("create")
+    if (c.kind === "create") expect(c.slug).toBe("antigravity")
+  })
+
+  test("title match with newer remote -> update carries blogDir", () => {
+    const local: LocalPostState[] = [
+      {
+        blogDir: "2020-foo-a",
+        title: "A",
+        updatedAt: new Date(500 * 1000),
+      },
+    ]
+    const plan = computePlan(remote, local)
+    const update = plan.actions.find((a) => a.kind === "update")
+    expect(update).toBeDefined()
+    if (update?.kind === "update") {
+      expect(update.page.id).toBe("0123456789abcdef01234567")
+      expect(update.blogDir).toBe("2020-foo-a")
+    }
+  })
+
+  test("title match with older-or-equal remote -> unchanged", () => {
+    const local: LocalPostState[] = [
+      {
+        blogDir: "2020-foo-a",
+        title: "A",
+        updatedAt: new Date(1000 * 1000),
+      },
+    ]
+    const plan = computePlan(remote, local)
+    const unchanged = plan.actions.find((a) => a.kind === "unchanged")
+    expect(unchanged).toBeDefined()
+  })
+
+  test("id match wins over title match (Cosense page renamed)", () => {
+    const local: LocalPostState[] = [
+      {
+        blogDir: "2020-renamed",
+        title: "Old Title",
+        cosenseId: "0123456789abcdef01234567",
+        updatedAt: new Date(500 * 1000),
+      },
+    ]
+    const plan = computePlan(remote, local)
+    const update = plan.actions.find((a) => a.kind === "update")
+    expect(update).toBeDefined()
+    if (update?.kind === "update") expect(update.blogDir).toBe("2020-renamed")
+  })
+
+  test("title comparison normalises NFC", () => {
+    const composed = "é"
+    const decomposed = "é"
+    const remoteNfd: CosenseListEntry[] = [
+      { id: "0123456789abcdef01234567", title: decomposed, updated: 1000 },
+    ]
+    const local: LocalPostState[] = [
+      { blogDir: "stub", title: composed, updatedAt: new Date(500 * 1000) },
+    ]
+    const plan = computePlan(remoteNfd, local)
+    expect(plan.actions[0].kind).toBe("update")
+  })
+
+  test("duplicate stub titles abort the whole run", () => {
+    const local: LocalPostState[] = [
+      { blogDir: "a", title: "Same", updatedAt: new Date(0) },
+      { blogDir: "b", title: "Same", updatedAt: new Date(0) },
+    ]
+    expect(() => computePlan(remote, local)).toThrow(/duplicate stub title/i)
+  })
+
+  test("delete: stub with cosenseId not in remote -> delete action", () => {
+    const local: LocalPostState[] = [
+      {
+        blogDir: "old-dir",
+        title: "Removed",
+        cosenseId: "999999999999999999999999",
+        updatedAt: new Date(0),
+      },
+    ]
+    const plan = computePlan(remote, local)
+    const del = plan.actions.find((a) => a.kind === "delete")
+    expect(del).toBeDefined()
+    if (del?.kind === "delete") {
+      expect(del.blogDir).toBe("old-dir")
+      expect(del.cosenseId).toBe("999999999999999999999999")
+    }
+  })
+
+  test("legacy stub WITHOUT cosenseId is never deleted", () => {
+    const local: LocalPostState[] = [
+      {
+        blogDir: "legacy",
+        title: "Legacy",
+        updatedAt: new Date(0),
+        // no cosenseId
+      },
+    ]
+    const plan = computePlan(remote, local)
+    const dels = plan.actions.filter((a) => a.kind === "delete")
+    expect(dels).toHaveLength(0)
+  })
+
+  test("plan combines create + update + unchanged + delete in one pass", () => {
+    const local: LocalPostState[] = [
+      // matches remote A by title (newer remote -> update)
+      {
+        blogDir: "stub-a",
+        title: "A",
+        updatedAt: new Date(500 * 1000),
+      },
+      // has cosenseId not in remote -> delete
+      {
+        blogDir: "stub-gone",
+        title: "Gone",
+        cosenseId: "999999999999999999999999",
+        updatedAt: new Date(0),
+      },
+      // legacy stub, no cosenseId, no remote match -> ignored
+      {
+        blogDir: "legacy",
+        title: "Legacy",
+        updatedAt: new Date(0),
+      },
+    ]
+    const plan = computePlan(remote, local)
+    const kinds = plan.actions.map((a) => a.kind).sort()
+    // remote A -> update; remote B -> create (no stub matches B);
+    // stub-gone -> delete; legacy -> nothing
+    expect(kinds).toEqual(["create", "delete", "update"])
+  })
+})
+```
+
+- [ ] **Step 2: Run the new tests and confirm they fail**
+
+Run: `pnpm test:unit lib/sync/diff.test.ts`
+
+Expected: failures from the existing diff implementation still emitting `skip` instead of `create`/`delete`, plus type errors at compile time.
+
+- [ ] **Step 3: Rewrite `lib/sync/diff.ts`**
+
+Open `lib/sync/diff.ts` and replace its **entire** contents with:
+
+```ts
+import { slugForTitle } from "./slug"
+import type { CosenseListEntry, SyncAction, SyncPlan } from "./types"
+
+export interface LocalPostState {
+  blogDir: string
+  title: string
+  cosenseId?: string
+  updatedAt: Date
+}
+
+function nfc(s: string): string {
+  return s.normalize("NFC")
+}
+
+export function computePlan(
+  remote: CosenseListEntry[],
+  local: LocalPostState[],
+): SyncPlan {
+  const byTitle = new Map<string, LocalPostState>()
+  const byId = new Map<string, LocalPostState>()
+  for (const stub of local) {
+    const key = nfc(stub.title)
+    if (byTitle.has(key)) {
+      throw new Error(
+        `duplicate stub title: ${JSON.stringify(stub.title)} (in ${stub.blogDir} and ${byTitle.get(key)!.blogDir})`,
+      )
+    }
+    byTitle.set(key, stub)
+    if (stub.cosenseId) byId.set(stub.cosenseId, stub)
+  }
+
+  const remoteIds = new Set(remote.map((p) => p.id))
+  const matchedStubs = new Set<LocalPostState>()
+  const actions: SyncAction[] = []
+
+  for (const page of remote) {
+    const stub = byId.get(page.id) ?? byTitle.get(nfc(page.title))
+    if (!stub) {
+      actions.push({
+        kind: "create",
+        page,
+        slug: slugForTitle(page.title, page.id),
+      })
+      continue
+    }
+    matchedStubs.add(stub)
+    if (Math.floor(stub.updatedAt.getTime() / 1000) >= page.updated) {
+      actions.push({ kind: "unchanged", id: page.id })
+    } else {
+      actions.push({ kind: "update", page, blogDir: stub.blogDir })
+    }
+  }
+
+  for (const stub of local) {
+    if (!stub.cosenseId) continue // legacy posts are never deleted
+    if (matchedStubs.has(stub)) continue // already handled as update/unchanged
+    if (remoteIds.has(stub.cosenseId)) continue // matched by id but title-search hit differently — paranoia
+    actions.push({
+      kind: "delete",
+      blogDir: stub.blogDir,
+      cosenseId: stub.cosenseId,
+    })
+  }
+
+  return { actions, stubCount: local.length }
+}
+```
+
+- [ ] **Step 4: Run the tests and confirm they pass**
+
+Run: `pnpm test:unit lib/sync/diff.test.ts`
+
+Expected: all 11 cases pass.
+
+- [ ] **Step 5: Run typecheck and lint**
+
+Run: `pnpm test && pnpm lint:ci`
+
+Expected: both pass. `scripts/sync-cosense.ts` was already type-clean during the Task 2/3 window (its action loop narrows on `kind: "update"` and falls through for the rest); now that `diff.ts` is fixed, the whole project tsc is green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/sync/diff.ts lib/sync/diff.test.ts
+git commit -m "diff: emit create/delete actions, drop skip; legacy stubs untouched"
+```
+
+---
+
+## Task 5: Orchestrator updates in `scripts/sync-cosense.ts`
+
+**Files:**
+- Modify: `scripts/sync-cosense.ts`
+- Modify: `scripts/sync-cosense.test.ts`
+
+This task wires the new `create` and `delete` actions into the orchestrator, adds threshold checking and slug-collision resolution, and integrates the per-page error tolerance for all action kinds. The branch becomes type-clean again at the end of this task.
+
+- [ ] **Step 1: Append failing integration tests**
+
+Open `scripts/sync-cosense.test.ts`. Replace the existing import line for the local module:
+
+Find:
+```ts
+import { runSync } from "./sync-cosense"
+```
+
+Replace with:
+```ts
+import { runSync } from "./sync-cosense"
+import { DeleteThresholdError } from "@/lib/sync/types"
+```
+
+Then append these tests after the last existing test in the file:
+
+```ts
+test("create: new Cosense page produces a stub directory with frontmatter and body", async () => {
+  // No local stubs, two remote pages -> two creates.
+  const fetchStub = vi
+    .fn()
+    .mockResolvedValue(new Response(new Uint8Array([1]), { status: 200 }))
+  const r = await runSync({
+    client: stubClient(),
+    postsRoot,
+    errorsPath,
+    dryRun: false,
+    fetch: fetchStub,
+  })
+  expect(r.errors).toHaveLength(0)
+  expect(r.plan.actions.map((a) => a.kind).sort()).toEqual([
+    "create",
+    "create",
+  ])
+  // Slugs are "a" and "b" -> length-1, falls back to page id
+  const dirs = readdirSync(postsRoot).sort()
+  expect(dirs).toEqual([
+    "0123456789abcdef01234567",
+    "fedcba9876543210fedcba98",
+  ])
+  const aOut = readFileSync(
+    join(postsRoot, "0123456789abcdef01234567", "index.md"),
+    "utf8",
+  )
+  expect(aOut).toContain('title: "A"')
+  expect(aOut).toContain("cosense_id: 0123456789abcdef01234567")
+  expect(aOut).toContain("Synced body line.")
+})
+
+test("create: ASCII title with sufficient length keeps the title slug", async () => {
+  const remoteAntigrav = {
+    count: 1,
+    pages: [
+      {
+        id: "1111111111111111111111aa",
+        title: "Antigravity",
+        updated: 2_000_000_000,
+      },
+    ],
+  }
+  const c = {
+    listPages: vi.fn().mockResolvedValue(remoteAntigrav),
+    getPage: vi
+      .fn()
+      .mockResolvedValue(detailFor("1111111111111111111111aa", "Antigravity")),
+  }
+  await runSync({
+    client: c,
+    postsRoot,
+    errorsPath,
+    dryRun: false,
+    fetch: vi
+      .fn()
+      .mockResolvedValue(new Response(new Uint8Array([1]), { status: 200 })),
+  })
+  expect(readdirSync(postsRoot)).toEqual(["antigravity"])
+})
+
+test("create: slug collision with a legacy stub appends a 6-hex suffix", async () => {
+  // A pre-existing legacy stub at "antigravity" with NO cosense_id.
+  await mkdir(join(postsRoot, "antigravity"), { recursive: true })
+  writeFileSync(
+    join(postsRoot, "antigravity", "index.md"),
+    "---\ntitle: 'Antigravity (legacy)'\n---\n\nlegacy body\n",
+  )
+  const remoteAntigrav = {
+    count: 1,
+    pages: [
+      {
+        id: "1111111111111111111111aa",
+        title: "Antigravity",
+        updated: 2_000_000_000,
+      },
+    ],
+  }
+  const c = {
+    listPages: vi.fn().mockResolvedValue(remoteAntigrav),
+    getPage: vi
+      .fn()
+      .mockResolvedValue(detailFor("1111111111111111111111aa", "Antigravity")),
+  }
+  await runSync({
+    client: c,
+    postsRoot,
+    errorsPath,
+    dryRun: false,
+    fetch: vi
+      .fn()
+      .mockResolvedValue(new Response(new Uint8Array([1]), { status: 200 })),
+  })
+  // Legacy is untouched; new stub gets the suffix from the first 6 hex
+  // chars of the page id (1111111111111111111111aa -> 111111).
+  const dirs = readdirSync(postsRoot).sort()
+  expect(dirs).toEqual(["antigravity", "antigravity-111111"])
+  expect(
+    readFileSync(join(postsRoot, "antigravity", "index.md"), "utf8"),
+  ).toContain("legacy body")
+  expect(
+    readFileSync(
+      join(postsRoot, "antigravity-111111", "index.md"),
+      "utf8",
+    ),
+  ).toContain("cosense_id: 1111111111111111111111aa")
+})
+
+test("delete: stub with cosense_id absent from remote is removed", async () => {
+  // Pre-existing stub with cosense_id that no longer matches any remote.
+  await makeStub(
+    "going-away",
+    "Going Away",
+    "2020-01-01T00:00:00.000Z",
+    "999999999999999999999999",
+  )
+  // Pre-existing stub for "A" so the run is not just deletes
+  await makeStub("a-stub", "A")
+  // Legacy stub WITHOUT cosense_id -> must survive
+  await makeStub("legacy", "Legacy Untouched")
+  const r = await runSync({
+    client: stubClient({
+      // remote only has A and B; "Going Away" disappeared
+    }),
+    postsRoot,
+    errorsPath,
+    dryRun: false,
+    fetch: vi
+      .fn()
+      .mockResolvedValue(new Response(new Uint8Array([1]), { status: 200 })),
+  })
+  expect(r.errors).toHaveLength(0)
+  const dirs = readdirSync(postsRoot).sort()
+  // a-stub remains (updated), going-away removed, legacy preserved,
+  // "fedcba9876543210fedcba98" created for B
+  expect(dirs).toEqual([
+    "a-stub",
+    "fedcba9876543210fedcba98",
+    "legacy",
+  ])
+})
+
+test("delete: legacy stub (no cosense_id) is never deleted even with no remote match", async () => {
+  await makeStub("legacy", "Legacy Untouched")
+  const c = {
+    listPages: vi.fn().mockResolvedValue({ count: 0, pages: [] }),
+    getPage: vi.fn(),
+  }
+  // count=0, ratio=0 -> thresholds pass; no deletes (legacy has no cosense_id)
+  const r = await runSync({
+    client: c,
+    postsRoot,
+    errorsPath,
+    dryRun: false,
+  })
+  expect(r.plan.actions).toHaveLength(0)
+  expect(readdirSync(postsRoot)).toEqual(["legacy"])
+})
+
+test("threshold: absolute count violation throws DeleteThresholdError before any deletes", async () => {
+  // Six stubs with cosense_id, none in remote -> 6 deletes -> exceeds default 5.
+  for (let i = 0; i < 6; i++) {
+    await makeStub(`gone-${i}`, `Gone ${i}`, "2020-01-01T00:00:00.000Z", `aaaaaaaaaaaaaaaaaaaaaa${i.toString().padStart(2, "0")}`)
+  }
+  const c = {
+    listPages: vi.fn().mockResolvedValue({ count: 0, pages: [] }),
+    getPage: vi.fn(),
+  }
+  await expect(
+    runSync({
+      client: c,
+      postsRoot,
+      errorsPath,
+      dryRun: false,
+      maxDeleteAbs: 5,
+      maxDeleteRatio: 1.0, // disable ratio gate
+    }),
+  ).rejects.toBeInstanceOf(DeleteThresholdError)
+  // No directory was deleted
+  expect(readdirSync(postsRoot).length).toBe(6)
+})
+
+test("threshold: ratio violation throws DeleteThresholdError", async () => {
+  // 4 stubs, all with cosense_id, none in remote -> ratio 1.0 > 0.05.
+  for (let i = 0; i < 4; i++) {
+    await makeStub(`gone-${i}`, `Gone ${i}`, "2020-01-01T00:00:00.000Z", `bbbbbbbbbbbbbbbbbbbbbb${i.toString().padStart(2, "0")}`)
+  }
+  const c = {
+    listPages: vi.fn().mockResolvedValue({ count: 0, pages: [] }),
+    getPage: vi.fn(),
+  }
+  await expect(
+    runSync({
+      client: c,
+      postsRoot,
+      errorsPath,
+      dryRun: false,
+      maxDeleteAbs: 100, // disable absolute gate
+      maxDeleteRatio: 0.05,
+    }),
+  ).rejects.toBeInstanceOf(DeleteThresholdError)
+})
+
+test("threshold: a single legitimate delete passes the default 5 / 0.05 thresholds", async () => {
+  // 1 cosense-sourced stub absent from remote, 19 still matching -> ratio 0.05.
+  await makeStub("gone", "Gone", "2020-01-01T00:00:00.000Z", "999999999999999999999999")
+  // 19 stubs whose titles match nothing in remote (no-op for them) is verbose;
+  // simpler: rely on the absolute gate. With 1 delete and default abs=5, pass.
+  const c = {
+    listPages: vi.fn().mockResolvedValue({ count: 0, pages: [] }),
+    getPage: vi.fn(),
+  }
+  await runSync({
+    client: c,
+    postsRoot,
+    errorsPath,
+    dryRun: false,
+    // ratio 1/1 = 1.0 -> would fail default ratio. Override to disable.
+    maxDeleteRatio: 1.0,
+  })
+  expect(readdirSync(postsRoot)).toEqual([])
+})
+```
+
+- [ ] **Step 2: Run the failing tests and confirm they fail**
+
+Run: `pnpm test:unit scripts/sync-cosense.test.ts`
+
+Expected: failures, primarily about `runSync` not accepting `maxDeleteAbs` / `maxDeleteRatio` and not honoring `create`/`delete` actions. The pre-existing 5 `update`/`dryRun` tests should still pass.
+
+- [ ] **Step 3: Rewrite `scripts/sync-cosense.ts`**
+
+Open `scripts/sync-cosense.ts` and replace its **entire** contents with:
+
+```ts
+// scripts/sync-cosense.ts
+import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises"
+import { join, resolve } from "node:path"
+import { z } from "zod"
+import { CosenseClient } from "@/lib/sync/cosense-client"
+import { computePlan, type LocalPostState } from "@/lib/sync/diff"
+import { createPost, deletePost, updatePost } from "@/lib/sync/fs-writer"
+import { downloadImages } from "@/lib/sync/images"
+import { parseFrontmatter } from "@/lib/sync/parse-frontmatter"
+import { transformPage } from "@/lib/sync/transform"
+import { DeleteThresholdError, type SyncPlan } from "@/lib/sync/types"
+
+const envSchema = z.object({
+  COSENSE_PROJECT: z.string().min(1),
+  COSENSE_SID: z.string().min(1),
+  MAX_DELETE_ABS: z.coerce.number().int().nonnegative().default(5),
+  MAX_DELETE_RATIO: z.coerce.number().nonnegative().default(0.05),
+})
+
+const POSTS_ROOT = resolve(process.cwd(), "content/posts")
+const PLAN_PATH = resolve(process.cwd(), ".sync-plan.json")
+const ERRORS_PATH = resolve(process.cwd(), ".sync-errors.json")
+
+interface Args {
+  dryRun: boolean
+}
+
+function parseArgs(argv: string[]): Args {
+  return {
+    dryRun: argv.includes("--dry-run") || process.env.SYNC_DRY_RUN === "true",
+  }
+}
+
+export interface SyncError {
+  title: string
+  error: string
+}
+
+export interface RunOptions {
+  client: Pick<CosenseClient, "listPages" | "getPage">
+  postsRoot: string
+  errorsPath: string
+  dryRun: boolean
+  fetch?: typeof globalThis.fetch
+  maxDeleteAbs?: number
+  maxDeleteRatio?: number
+}
+
+export interface RunResult {
+  plan: SyncPlan
+  errors: SyncError[]
+}
+
+async function dirExists(p: string): Promise<boolean> {
+  try {
+    await stat(p)
+    return true
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return false
+    throw err
+  }
+}
+
+async function resolveCreateSlug(
+  postsRoot: string,
+  preferredSlug: string,
+  pageId: string,
+): Promise<string> {
+  if (!(await dirExists(join(postsRoot, preferredSlug)))) return preferredSlug
+  const withSuffix = `${preferredSlug}-${pageId.slice(0, 6)}`
+  if (!(await dirExists(join(postsRoot, withSuffix)))) return withSuffix
+  throw new Error(
+    `slug collision: both ${preferredSlug}/ and ${withSuffix}/ already exist`,
+  )
+}
+
+export async function runSync(opts: RunOptions): Promise<RunResult> {
+  const list = await opts.client.listPages()
+  const local = await readLocalStateAt(opts.postsRoot)
+  const plan = computePlan(list.pages, local)
+
+  if (opts.dryRun) return { plan, errors: [] }
+
+  // --- Threshold check (BEFORE any side effects) ---
+  const maxAbs = opts.maxDeleteAbs ?? 5
+  const maxRatio = opts.maxDeleteRatio ?? 0.05
+  const deleteCount = plan.actions.filter((a) => a.kind === "delete").length
+  const cosenseSourced = local.filter((s) => s.cosenseId).length
+  const ratio = cosenseSourced > 0 ? deleteCount / cosenseSourced : 0
+  if (deleteCount > maxAbs) {
+    throw new DeleteThresholdError(
+      `delete count ${deleteCount} exceeds MAX_DELETE_ABS=${maxAbs}`,
+    )
+  }
+  if (ratio > maxRatio) {
+    throw new DeleteThresholdError(
+      `delete ratio ${ratio.toFixed(3)} exceeds MAX_DELETE_RATIO=${maxRatio.toFixed(3)}`,
+    )
+  }
+
+  const errors: SyncError[] = []
+  for (const action of plan.actions) {
+    try {
+      if (action.kind === "update") {
+        const page = await opts.client.getPage(action.page.title)
+        const post = transformPage(page)
+        const dir = join(opts.postsRoot, action.blogDir)
+        await downloadImages(post.images, dir, { fetch: opts.fetch })
+        await updatePost(post, dir)
+      } else if (action.kind === "create") {
+        const page = await opts.client.getPage(action.page.title)
+        const post = transformPage(page)
+        const finalSlug = await resolveCreateSlug(
+          opts.postsRoot,
+          action.slug,
+          page.id,
+        )
+        const dir = join(opts.postsRoot, finalSlug)
+        await mkdir(dir, { recursive: false })
+        try {
+          await downloadImages(post.images, dir, { fetch: opts.fetch })
+          await createPost(post, dir)
+        } catch (innerErr) {
+          // Rollback an empty/partial dir so the next tick is clean.
+          await deletePost(dir).catch(() => {})
+          throw innerErr
+        }
+      } else if (action.kind === "delete") {
+        await deletePost(join(opts.postsRoot, action.blogDir))
+      }
+      // unchanged: nothing to do
+    } catch (err) {
+      const title =
+        action.kind === "delete"
+          ? `(delete cosense_id ${action.cosenseId})`
+          : action.page.title
+      errors.push({
+        title,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  if (errors.length > 0) {
+    await writeFile(opts.errorsPath, JSON.stringify(errors, null, 2))
+  }
+  return { plan, errors }
+}
+
+async function readLocalStateAt(postsRoot: string): Promise<LocalPostState[]> {
+  let entries: string[]
+  try {
+    entries = await readdir(postsRoot)
+  } catch {
+    return []
+  }
+  const out: LocalPostState[] = []
+  for (const dir of entries) {
+    let text: string
+    try {
+      text = await readFile(join(postsRoot, dir, "index.md"), "utf8")
+    } catch {
+      continue
+    }
+    const fm = parseFrontmatter(text)
+    if (!fm.title) continue
+    out.push({
+      blogDir: dir,
+      title: fm.title,
+      cosenseId: fm.cosense_id,
+      updatedAt: fm.updated_at ? new Date(fm.updated_at) : new Date(0),
+    })
+  }
+  return out
+}
+
+function summarise(plan: SyncPlan, errors: SyncError[]): string {
+  let create = 0
+  let update = 0
+  let unchanged = 0
+  let del = 0
+  for (const a of plan.actions) {
+    if (a.kind === "create") create++
+    else if (a.kind === "update") update++
+    else if (a.kind === "unchanged") unchanged++
+    else if (a.kind === "delete") del++
+  }
+  return `plan: ${create} create, ${update} update, ${unchanged} unchanged, ${del} delete, ${errors.length} errors (stubs: ${plan.stubCount})`
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const args = parseArgs(process.argv.slice(2))
+  const env = envSchema.parse(process.env)
+  runSync({
+    client: new CosenseClient({
+      project: env.COSENSE_PROJECT,
+      sid: env.COSENSE_SID,
+    }),
+    postsRoot: POSTS_ROOT,
+    errorsPath: ERRORS_PATH,
+    dryRun: args.dryRun,
+    maxDeleteAbs: env.MAX_DELETE_ABS,
+    maxDeleteRatio: env.MAX_DELETE_RATIO,
+  })
+    .then(async ({ plan, errors }) => {
+      console.log(summarise(plan, errors))
+      if (args.dryRun) {
+        await writeFile(PLAN_PATH, JSON.stringify(plan, null, 2))
+      }
+    })
+    .catch((err) => {
+      console.error(err)
+      process.exit(1)
+    })
+}
+```
+
+- [ ] **Step 4: Run all unit tests and confirm green**
+
+Run: `pnpm test:unit`
+
+Expected: all tests across `lib/sync/*.test.ts` and `scripts/*.test.ts` pass. The new `create`/`delete`/threshold scenarios pass alongside the pre-existing dry-run, update, idempotency, and per-page-error tests.
+
+- [ ] **Step 5: Run typecheck and lint**
+
+Run: `pnpm test && pnpm lint:ci`
+
+Expected: both succeed cleanly. The branch is fully type-clean again.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/sync-cosense.ts scripts/sync-cosense.test.ts
+git commit -m "sync orchestrator: dispatch create/delete with threshold + slug-collision guards"
+```
+
+---
+
+## Task 6: Workflow YAML threshold env
+
+**Files:**
+- Modify: `.github/workflows/sync.yml`
+
+This task wires the two threshold env vars into the GitHub Actions workflow. It is a one-step edit.
+
+- [ ] **Step 1: Add threshold env to the `Run sync` step**
+
+Open `.github/workflows/sync.yml`. Find the `Run sync` step:
+
+```yaml
+      - name: Run sync
+        id: sync
+        continue-on-error: true
+        run: pnpm sync ${{ inputs.dry_run && '--dry-run' || '' }}
+        env:
+          COSENSE_PROJECT: ${{ secrets.COSENSE_PROJECT }}
+          COSENSE_SID:     ${{ secrets.COSENSE_SID }}
+```
+
+Add `MAX_DELETE_ABS` and `MAX_DELETE_RATIO` under `env:`:
+
+```yaml
+      - name: Run sync
+        id: sync
+        continue-on-error: true
+        run: pnpm sync ${{ inputs.dry_run && '--dry-run' || '' }}
+        env:
+          COSENSE_PROJECT:  ${{ secrets.COSENSE_PROJECT }}
+          COSENSE_SID:      ${{ secrets.COSENSE_SID }}
+          MAX_DELETE_ABS:   '5'
+          MAX_DELETE_RATIO: '0.05'
+```
+
+The values are quoted strings because GitHub Actions env values are always strings; zod's `z.coerce.number()` in `envSchema` parses them.
+
+- [ ] **Step 2: Inspect the diff**
+
+Run: `git diff .github/workflows/sync.yml`
+
+Expected: only the two new env entries added; no other lines changed; the `COSENSE_PROJECT` / `COSENSE_SID` lines are re-aligned by one space to keep the column flush, which is acceptable cosmetic drift.
+
+- [ ] **Step 3: Run all checks**
+
+Run: `pnpm test && pnpm lint:ci && pnpm test:unit`
+
+Expected: all three succeed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/sync.yml
+git commit -m "sync workflow: expose MAX_DELETE_ABS=5 and MAX_DELETE_RATIO=0.05 env"
+```
+
+---
+
+## Verification checklist (run before opening the PR)
+
+- [ ] `pnpm test` (tsc) — passes.
+- [ ] `pnpm lint:ci` — passes.
+- [ ] `pnpm test:unit` — all `lib/sync/*.test.ts` and `scripts/*.test.ts` pass; no regressions in `scripts/sync-report-health.test.ts`.
+- [ ] `git diff origin/main..HEAD --stat` shows exactly these files (plus the spec/plan from prior commits): `lib/sync/types.ts`, `lib/sync/slug.ts`, `lib/sync/slug.test.ts`, `lib/sync/diff.ts`, `lib/sync/diff.test.ts`, `lib/sync/fs-writer.ts`, `lib/sync/fs-writer.test.ts`, `scripts/sync-cosense.ts`, `scripts/sync-cosense.test.ts`, `.github/workflows/sync.yml`.
+- [ ] `scripts/sync-report-health.ts` and `scripts/sync-report-health.test.ts` are byte-for-byte unchanged on this branch (`git diff origin/main..HEAD -- scripts/sync-report-health.ts scripts/sync-report-health.test.ts` returns empty).
+- [ ] `content/posts/**` is unchanged (no static edits land in this branch).
+
+---
+
+## Out of scope (do not add)
+
+- Backfilling the 61 legacy posts to Cosense.
+- Bidirectional sync (writes to Cosense).
+- A `draft: true` frontmatter flag for soft-deletes.
+- Migrating the 48 already-matched stubs to a different URL scheme.
+- Splitting `scripts/sync-cosense.ts` into smaller files. The orchestrator's responsibilities are in one place by design and will exceed 200 lines after this task — that is acceptable per the existing pattern.
+
+If the implementer encounters a question whose answer would require extending into these areas, stop and ask before proceeding.

--- a/docs/superpowers/specs/2026-05-04-cosense-phase-4-design.md
+++ b/docs/superpowers/specs/2026-05-04-cosense-phase-4-design.md
@@ -1,0 +1,352 @@
+# 2026-05-04: Cosense sync — Phase 4 (auto-publish + delete propagation)
+
+## Context
+
+Phase 2 (PR #702) reframed the sync model from Phase 1's "every Cosense
+page becomes a blog post" to "a blog post stub is the publishing
+decision". The intent at the time was to protect 48 already-matched
+posts from URL drift and to leave 3 Cosense pages
+(`Antigravity`, `clay`, `kashitaka`) unpublished until the author
+manually opted them in.
+
+In production use this opt-in step turned out to be the wrong
+default. The author's intent is "anything I write on Cosense should
+appear on the blog by default", and the manual stub creation has
+become friction with no upside — there are no draft-only Cosense
+pages the author wants to keep private. Cosense effectively *is* the
+blog.
+
+This phase reverses Phase 2's opt-in pivot for Cosense-sourced posts
+while keeping its other improvements (title-then-id matching,
+per-page error tolerance, atomic writes, `cosense_id` stamping). The
+61 legacy blog-only posts are left untouched, distinguished by the
+absence of a `cosense_id` field in their frontmatter.
+
+## Mental model
+
+| Concept                                 | Owner / lifecycle                                                    |
+|-----------------------------------------|----------------------------------------------------------------------|
+| Cosense page                            | Source of truth for any blog post that has a `cosense_id`            |
+| Blog post **with** `cosense_id`         | Reflection of Cosense; sync may create, update, or delete it         |
+| Blog post **without** `cosense_id` (61) | Hand-authored legacy; sync never touches it                          |
+| Cosense page that disappears            | Triggers deletion of the blog post directory on the next sync        |
+
+The `cosense_id` field is the contract that opts a directory in to
+sync. Posts that have it are tracked by Cosense; posts that do not
+are owned by the repo and never modified by sync.
+
+## Goals
+
+1. A new Cosense page appears on the blog within one cron tick of
+   creation, with a stable URL slug derived from its title (or the
+   page id as a fallback for non-ASCII titles).
+2. A Cosense page that the author deletes vanishes from the blog
+   within one cron tick of deletion. Removal is mechanical: the
+   post's directory under `content/posts/` is removed.
+3. The 61 legacy blog-only posts (no `cosense_id`) are never touched
+   by sync — neither read for diff purposes beyond identity, nor
+   modified, nor deleted.
+4. Renaming or retitling a Cosense page propagates without breaking
+   URLs: the existing stub directory is preserved, the frontmatter
+   `title` is updated, and the URL stays at its original slug.
+5. A catastrophic Cosense response (empty list, partial pagination,
+   schema drift) cannot delete more posts than a documented threshold
+   permits. Above the threshold, sync aborts and Phase 3's health
+   reporter opens a `sync-broken` issue.
+
+## Non-goals
+
+1. **Backfilling the 61 legacy posts to Cosense.** Out of scope —
+   they are valid as-is and rewriting them on Cosense would be
+   error-prone.
+2. **Bidirectional sync (blog → Cosense).** Out of scope. The
+   author writes only on Cosense.
+3. **Soft-deletes / drafts / unpublished states.** A deleted Cosense
+   page deletes the blog post immediately. There is no
+   intermediate "archived" state.
+4. **Post body preservation across deletes.** When a Cosense page is
+   deleted, the corresponding blog post directory and any locally
+   downloaded images go with it. The author can recover from git
+   history if needed.
+5. **Migrating the 48 already-matched stubs to a different URL
+   scheme.** Existing slugs (manually chosen years ago) stay where
+   they are — matching by `cosense_id` ensures sync follows the
+   directory regardless of slug shape.
+
+## Architecture
+
+The sync engine reverts two of Phase 2's deliberate restrictions:
+
+1. **`SyncAction.create` is reintroduced.** A Cosense page that has
+   no matching stub by `cosense_id` *or* title produces a `create`
+   action. The orchestrator calls a new `createPost(post, postsRoot)`
+   that writes a fresh `<postsRoot>/<slug>/index.md` with full
+   frontmatter (`title`, `created_at`, `updated_at`, `cosense_id`)
+   and downloads any referenced images.
+2. **`SyncAction.delete` is reintroduced.** A stub that has a
+   `cosense_id` whose value is no longer in the Cosense page list
+   produces a `delete` action. The orchestrator calls
+   `deletePost(blogDir)` to remove the directory.
+3. **`SyncAction.skip` is removed.** Phase 2's "no-stub means skip"
+   behavior is replaced by `create`. The `kind: "skip"` variant goes
+   away, along with the `reason` field.
+
+The 61 legacy posts are protected by a structural invariant: only
+stubs whose frontmatter contains a `cosense_id` are eligible for
+`delete`. A stub without `cosense_id` is invisible to the diff
+stage's delete pass.
+
+```
+┌──────────────────────┐     ┌──────────────────────┐
+│ Cosense list         │     │ content/posts/       │
+│ (51 pages)           │     │  ├─ <existing-48>/   │ cosense_id present
+│                      │     │  │   (matched)        │
+│                      │     │  ├─ <legacy-61>/      │ NO cosense_id
+│                      │     │  │   (untouched)      │
+│                      │     │  └─ <new-3>/          │ created by sync
+└──────────┬───────────┘     └──────────┬───────────┘
+           │                            │
+           └─────────►  diff  ◄─────────┘
+                          │
+                          ▼
+              ┌──────────────────────┐
+              │ create | update |    │
+              │ unchanged | delete   │
+              └──────────────────────┘
+```
+
+## Slug strategy for newly-created stubs
+
+For `update` actions the directory name is fixed (the stub already
+exists). Slug logic only matters for `create` actions.
+
+`lib/sync/slug.ts` gains `slugForTitle(title, pageId): string`:
+
+1. ASCII-slugify the title: lowercase, strip everything that is not
+   `[a-z0-9\s-]`, collapse whitespace runs to a single `-`, collapse
+   `--+` runs, trim leading and trailing `-`.
+2. If the resulting slug is at least 3 characters long, use it.
+3. Otherwise, return the 24-hex `pageId` as the slug. (Pure-CJK
+   titles fall through to this path; the URL is uglier but stable
+   and collision-free.)
+
+Collision handling — performed by the orchestrator, not by `slug.ts`:
+
+- If `<postsRoot>/<slug>/` already exists when applying a `create`
+  action, append the first 6 characters of `pageId` to produce
+  `<slug>-<short-id>`.
+- If `<postsRoot>/<slug>-<short-id>/` *also* exists, abort the
+  whole sync with a clear error. This case is statistically
+  unreachable (collision on the first 6 hex digits requires both a
+  title clash and a partial id clash) and is treated as an
+  invariant violation rather than a routine code path.
+
+The 48 currently-matched stubs are not affected: their directories
+already exist, sync routes them through `update`, and `slug.ts` is
+never called.
+
+## Delete propagation safety
+
+A pair of thresholds guards against catastrophic Cosense API states
+(empty list during an outage, partial pagination, schema drift that
+the zod schema fails to parse):
+
+| Env var               | Default | Meaning                                                       |
+|-----------------------|---------|---------------------------------------------------------------|
+| `MAX_DELETE_ABS`      | `5`     | Hard upper bound on the number of `delete` actions per run.   |
+| `MAX_DELETE_RATIO`    | `0.05`  | Upper bound on `deletes / total-cosense-sourced-stubs` ratio. |
+
+Either threshold violated → orchestrator throws a typed
+`DeleteThresholdError` with the offending counts. The throw is
+caught by the workflow's existing error path (the sync step is
+already `continue-on-error: true` per Phase 3); Phase 3's health
+reporter sees `SYNC_STATUS=failure` and opens a `sync-broken` issue
+with the run URL. No deletes are performed in that run.
+
+The next cron tick re-evaluates against fresh Cosense state. If the
+underlying outage has cleared, the run succeeds and the reporter
+closes the issue automatically.
+
+The thresholds are configurable via the workflow YAML's `env:` block
+on the `Run sync` step. The workflow change is a one-line addition;
+no separate phase is needed.
+
+A typical legitimate single-page deletion (1 page out of ~51,
+ratio 0.02) passes both thresholds. Cosense returning an empty list
+(51 deletes, ratio 1.0) fails both. A bug that mistakes 10 unrelated
+pages for deletions (ratio 0.20) fails the ratio.
+
+## Edge cases
+
+| Case                                                  | Behavior                                                                                              |
+|-------------------------------------------------------|-------------------------------------------------------------------------------------------------------|
+| Cosense page renamed (title change, id stable)        | Matched by `cosense_id`. URL unchanged. Frontmatter `title` and body refreshed.                       |
+| Cosense page id changes (rare, e.g. project migrate)  | Matched by `nfc(title)` fallback. URL unchanged. Frontmatter `cosense_id` updated.                    |
+| Cosense title duplicates an existing legacy slug      | New stub's slug gets `-<6-hex>` suffix. Original legacy post untouched.                               |
+| Cosense title has no ASCII content                    | Slug is the 24-hex `pageId`. URL is `/0123456789abcdef01234567/` shape.                               |
+| Stub has stale `cosense_id` (id no longer in Cosense) | `delete` candidate, subject to thresholds.                                                            |
+| Stub has stale `cosense_id` AND title matches a remote| Handled in diff order: cosense_id lookup misses, title lookup hits → `update`. No phantom delete.     |
+| Cosense list returns 0 pages                          | All Cosense-sourced stubs become delete candidates. Threshold trips. Run aborts; nothing deleted.     |
+| zod schema parse fails (drift)                        | Orchestrator throws before diff runs. Phase 3 reporter handles surfacing.                             |
+| Per-page `getPage` / `createPost` / `deletePost` fails | Tolerated by Phase 2's per-page error path: error logged to `.sync-errors.json`, run continues, Phase 3 reporter surfaces. |
+| Race between sync and a manual git push               | Atomic file rename inside `updatePost`/`createPost` plus directory-level `deletePost` minimize harm. Final consistency restored on next cron tick. |
+
+## Components
+
+### Modified
+
+**`lib/sync/types.ts`**
+- `SyncAction` union becomes:
+  ```ts
+  export type SyncAction =
+    | { kind: "create"; page: CosenseListEntry; slug: string }
+    | { kind: "update"; page: CosenseListEntry; blogDir: string }
+    | { kind: "unchanged"; id: string }
+    | { kind: "delete"; blogDir: string; cosenseId: string }
+  ```
+  (`skip` is removed; `create` and `delete` are added.)
+  The `slug` on a `create` action is the *preferred* slug from
+  `slugForTitle`. The orchestrator may append a `-<6-hex>` suffix
+  at apply time if the directory already exists; the diff stage
+  does not touch the filesystem.
+- New error class `DeleteThresholdError` exported for orchestrator
+  use.
+
+**`lib/sync/diff.ts`**
+- Inputs unchanged.
+- For each remote page:
+  - matched by `cosense_id` or `nfc(title)` → emit `update` or
+    `unchanged` per the existing time comparison.
+  - unmatched → emit `create` with `slug = slugForTitle(page.title, page.id)`.
+- For each local stub with `cosenseId` set and no matching remote
+  page (by id) → emit `delete`.
+- Local stubs *without* `cosenseId` are not considered for delete.
+- Duplicate-title check stays.
+
+**`lib/sync/slug.ts`**
+- Add `slugForTitle(title: string, pageId: string): string` per the
+  algorithm above.
+- `slugForPageId` and `isValidSlug` retained.
+
+**`lib/sync/fs-writer.ts`**
+- Add `createPost(post: Post, postsRoot: string, slug: string): Promise<void>`:
+  - Computes `blogDir = join(postsRoot, slug)`.
+  - Throws if `blogDir` already exists (orchestrator handles
+    collision recovery before calling).
+  - Renders a fresh `index.md` with frontmatter:
+    ```yaml
+    ---
+    title: <quoted>
+    created_at: '<ISO8601>'
+    updated_at: '<ISO8601>'
+    cosense_id: <24-hex>
+    ---
+
+    <body>
+    ```
+  - Writes via the same `tmp + rename` atomic pattern used by
+    `updatePost`.
+  - Image downloading (`downloadImages`) is invoked from the
+    orchestrator, not from `createPost` (mirrors the existing
+    `update` path).
+- Add `deletePost(blogDir: string): Promise<void>`:
+  - Recursively removes `blogDir`. Idempotent if `blogDir` does not
+    exist (treats ENOENT as a no-op so a retry after partial
+    failure converges).
+- Existing `updatePost` is unchanged.
+
+**`scripts/sync-cosense.ts`**
+- Read `MAX_DELETE_ABS` (default 5) and `MAX_DELETE_RATIO` (default
+  0.05) from `process.env` via the existing zod schema.
+- After computing the plan, count `delete` actions; if either
+  threshold is exceeded, throw `DeleteThresholdError` (the workflow
+  already turns this into a `sync-broken` issue via Phase 3's
+  reporter).
+- Dispatch `create` and `delete` actions in addition to the existing
+  `update` and `unchanged`. Each per-action call (create, update,
+  delete) runs inside the existing per-page `try/catch` so a single
+  failure is logged to `.sync-errors.json` without aborting the
+  rest of the run, exactly as Phase 2 does for `update`.
+- For `create`: resolve collision (suffix with first 6 hex of
+  `pageId` if `<slug>/` exists). If `<slug>-<short-id>/` also
+  exists, throw a clearly-named error (`SlugCollisionError`).
+
+### Tests modified or added
+
+- `lib/sync/types.test.ts` — N/A (no behavior, schema only).
+- `lib/sync/diff.test.ts` — replace `skip`-based cases with
+  `create`-based cases; add cases for `delete` (cosense_id-bearing
+  stub absent from remote → delete; legacy stub absent from remote
+  → ignored).
+- `lib/sync/slug.test.ts` — add cases for `slugForTitle`: pure
+  English title, mixed Japanese/English, pure-CJK title (page-id
+  fallback), short-result title (page-id fallback), title with
+  punctuation only.
+- `lib/sync/fs-writer.test.ts` — add cases for `createPost`
+  (fresh write, throws on existing dir, atomic rename) and
+  `deletePost` (removes directory, ENOENT no-op).
+- `scripts/sync-cosense.test.ts` — add scenarios:
+  1. New Cosense page with no matching stub → `create` action runs,
+     stub directory is born with frontmatter and body.
+  2. Cosense page deleted → `delete` action runs, stub directory is
+     removed; legacy stubs unaffected.
+  3. Slug collision with legacy stub → suffix path used.
+  4. Threshold violation → orchestrator throws, no deletes
+     performed.
+
+### Untouched
+
+- `scripts/sync-report-health.ts` — Phase 3's reporter reads only
+  exit status and `.sync-errors.json`; the new `delete` action and
+  threshold throw need no special handling there.
+- `.github/workflows/sync.yml` — gains two env entries
+  (`MAX_DELETE_ABS`, `MAX_DELETE_RATIO`) on the `Run sync` step.
+  No structural changes.
+- `lib/sync/cosense-client.ts`, `lib/sync/transform.ts`,
+  `lib/sync/scrapbox-to-md.ts`, `lib/sync/parse-frontmatter.ts`,
+  `lib/sync/images.ts`.
+- `app/`, `components/`, `styles/`, `velite.config.ts`.
+
+## Migration
+
+The first sync run after Phase 4 lands will:
+
+- Update bodies for the 48 currently-matched posts (no slug change).
+- Create 3 new posts: `Antigravity`, `clay`, `kashitaka`. Slugs are
+  derived from titles (`antigravity`, `clay`, `kashitaka`).
+  `created_at` is taken from each Cosense page's `created` field;
+  `cosense_id` is stamped.
+- Delete 0 posts. (No Cosense page has been deleted; nothing trips
+  the threshold.)
+
+The 61 legacy posts are untouched.
+
+The author's first observation will be three new posts appearing on
+the blog. From then on, the relationship is "Cosense is the source
+of truth; the blog mirrors it".
+
+## Rollout
+
+1. Merge the Phase 4 PR. The cron schedule is unchanged.
+2. Confirm the next cron tick (within 30 minutes) creates the three
+   expected posts and reports `sync-report-health: noop`.
+3. Optional smoke test for delete propagation: rename or
+   temporarily delete one Cosense page on the project, wait for the
+   next tick, observe the corresponding blog directory disappearing
+   (and reappearing on restoration). Both threshold defaults
+   (`5` absolute, `5%` ratio) make a single-page deletion pass.
+
+## Open questions resolved during brainstorming
+
+- **Auto-publish vs. opt-in:** The author confirmed that drafts on
+  Cosense are not a use case; everything written is intended for
+  publication. Phase 2's opt-in model is reverted for
+  Cosense-sourced posts.
+- **Unpublish path:** Deletion on Cosense triggers deletion on the
+  blog. No separate `draft: true` flag is added.
+- **Slug strategy for non-ASCII titles:** Page-id fallback is
+  preferred over a transliteration step (which would be lossy and
+  non-reversible). The 3 known unmatched pages have ASCII titles
+  and avoid this case in practice.
+- **Catastrophic delete protection:** Two thresholds (`5` absolute,
+  `5%` ratio) instead of a single one. Either trips abort.

--- a/lib/sync/diff.test.ts
+++ b/lib/sync/diff.test.ts
@@ -8,10 +8,28 @@ const remote: CosenseListEntry[] = [
 ]
 
 describe("computePlan", () => {
-  test("no stubs -> all skip", () => {
+  test("no stubs: every remote page becomes a create with a slug from title", () => {
     const plan = computePlan(remote, [])
-    expect(plan.actions.map((a) => a.kind)).toEqual(["skip", "skip"])
-    expect(plan.stubCount).toBe(0)
+    expect(plan.actions.map((a) => a.kind).sort()).toEqual(["create", "create"])
+    const a = plan.actions.find(
+      (act) => act.kind === "create" && act.page.title === "A",
+    )
+    if (!a || a.kind !== "create") throw new Error("expected a create for A")
+    expect(a.slug).toBe("0123456789abcdef01234567") // length-1 "a" falls back
+  })
+
+  test("create with a long-enough ASCII title uses the slug as-is", () => {
+    const single: CosenseListEntry[] = [
+      {
+        id: "0123456789abcdef01234567",
+        title: "Antigravity",
+        updated: 1000,
+      },
+    ]
+    const plan = computePlan(single, [])
+    const c = plan.actions[0]
+    expect(c.kind).toBe("create")
+    if (c.kind === "create") expect(c.slug).toBe("antigravity")
   })
 
   test("title match with newer remote -> update carries blogDir", () => {
@@ -45,7 +63,6 @@ describe("computePlan", () => {
   })
 
   test("id match wins over title match (Cosense page renamed)", () => {
-    // Cosense page id matches a stub even though title now differs.
     const local: LocalPostState[] = [
       {
         blogDir: "2020-renamed",
@@ -60,20 +77,9 @@ describe("computePlan", () => {
     if (update?.kind === "update") expect(update.blogDir).toBe("2020-renamed")
   })
 
-  test("no matching stub -> skip with title", () => {
-    const plan = computePlan(remote, [])
-    const skip = plan.actions[0]
-    expect(skip.kind).toBe("skip")
-    if (skip.kind === "skip") {
-      expect(skip.title).toBe("A")
-      expect(skip.reason).toBe("no-stub")
-    }
-  })
-
   test("title comparison normalises NFC", () => {
-    // Single composed character vs decomposed (NFD) form of the same string.
-    const composed = "é" // é (NFC, single codepoint)
-    const decomposed = "é" // é (NFD, e + combining acute)
+    const composed = "é"
+    const decomposed = "é"
     const remoteNfd: CosenseListEntry[] = [
       { id: "0123456789abcdef01234567", title: decomposed, updated: 1000 },
     ]
@@ -90,5 +96,66 @@ describe("computePlan", () => {
       { blogDir: "b", title: "Same", updatedAt: new Date(0) },
     ]
     expect(() => computePlan(remote, local)).toThrow(/duplicate stub title/i)
+  })
+
+  test("delete: stub with cosenseId not in remote -> delete action", () => {
+    const local: LocalPostState[] = [
+      {
+        blogDir: "old-dir",
+        title: "Removed",
+        cosenseId: "999999999999999999999999",
+        updatedAt: new Date(0),
+      },
+    ]
+    const plan = computePlan(remote, local)
+    const del = plan.actions.find((a) => a.kind === "delete")
+    expect(del).toBeDefined()
+    if (del?.kind === "delete") {
+      expect(del.blogDir).toBe("old-dir")
+      expect(del.cosenseId).toBe("999999999999999999999999")
+    }
+  })
+
+  test("legacy stub WITHOUT cosenseId is never deleted", () => {
+    const local: LocalPostState[] = [
+      {
+        blogDir: "legacy",
+        title: "Legacy",
+        updatedAt: new Date(0),
+        // no cosenseId
+      },
+    ]
+    const plan = computePlan(remote, local)
+    const dels = plan.actions.filter((a) => a.kind === "delete")
+    expect(dels).toHaveLength(0)
+  })
+
+  test("plan combines create + update + unchanged + delete in one pass", () => {
+    const local: LocalPostState[] = [
+      // matches remote A by title (newer remote -> update)
+      {
+        blogDir: "stub-a",
+        title: "A",
+        updatedAt: new Date(500 * 1000),
+      },
+      // has cosenseId not in remote -> delete
+      {
+        blogDir: "stub-gone",
+        title: "Gone",
+        cosenseId: "999999999999999999999999",
+        updatedAt: new Date(0),
+      },
+      // legacy stub, no cosenseId, no remote match -> ignored
+      {
+        blogDir: "legacy",
+        title: "Legacy",
+        updatedAt: new Date(0),
+      },
+    ]
+    const plan = computePlan(remote, local)
+    const kinds = plan.actions.map((a) => a.kind).sort()
+    // remote A -> update; remote B -> create (no stub matches B);
+    // stub-gone -> delete; legacy -> nothing
+    expect(kinds).toEqual(["create", "delete", "update"])
   })
 })

--- a/lib/sync/diff.ts
+++ b/lib/sync/diff.ts
@@ -1,3 +1,4 @@
+import { slugForTitle } from "./slug"
 import type { CosenseListEntry, SyncAction, SyncPlan } from "./types"
 
 export interface LocalPostState {
@@ -28,18 +29,38 @@ export function computePlan(
     if (stub.cosenseId) byId.set(stub.cosenseId, stub)
   }
 
+  const remoteIds = new Set(remote.map((p) => p.id))
+  const matchedStubs = new Set<LocalPostState>()
   const actions: SyncAction[] = []
+
   for (const page of remote) {
     const stub = byId.get(page.id) ?? byTitle.get(nfc(page.title))
     if (!stub) {
-      actions.push({ kind: "skip", title: page.title, reason: "no-stub" })
+      actions.push({
+        kind: "create",
+        page,
+        slug: slugForTitle(page.title, page.id),
+      })
       continue
     }
+    matchedStubs.add(stub)
     if (Math.floor(stub.updatedAt.getTime() / 1000) >= page.updated) {
       actions.push({ kind: "unchanged", id: page.id })
     } else {
       actions.push({ kind: "update", page, blogDir: stub.blogDir })
     }
   }
+
+  for (const stub of local) {
+    if (!stub.cosenseId) continue // legacy posts are never deleted
+    if (matchedStubs.has(stub)) continue // already handled as update/unchanged
+    if (remoteIds.has(stub.cosenseId)) continue // matched by id but title-search hit differently — paranoia
+    actions.push({
+      kind: "delete",
+      blogDir: stub.blogDir,
+      cosenseId: stub.cosenseId,
+    })
+  }
+
   return { actions, stubCount: local.length }
 }

--- a/lib/sync/fs-writer.test.ts
+++ b/lib/sync/fs-writer.test.ts
@@ -9,7 +9,7 @@ import { mkdir } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, expect, test } from "vitest"
-import { updatePost } from "./fs-writer"
+import { createPost, deletePost, updatePost } from "./fs-writer"
 import type { Post } from "./types"
 
 let root: string
@@ -136,4 +136,58 @@ test("throws clear error when stub frontmatter is malformed", async () => {
 test("throws when stub index.md does not exist", async () => {
   const dir = join(root, "missing")
   await expect(updatePost(post, dir)).rejects.toThrow(/ENOENT|no such file/i)
+})
+
+test("createPost: writes a fresh index.md with full frontmatter", async () => {
+  const dir = join(root, "antigravity")
+  await mkdir(dir, { recursive: true })
+  await createPost(post, dir)
+  const out = readFileSync(join(dir, "index.md"), "utf8")
+  expect(out).toContain('title: "Sample"')
+  expect(out).toContain("created_at: '2026-05-01T00:00:00.000Z'")
+  expect(out).toContain("updated_at: '2026-05-04T00:00:00.000Z'")
+  expect(out).toContain("cosense_id: 0123456789abcdef01234567")
+  expect(out).toContain("\n\nHello body.\n")
+})
+
+test("createPost: throws when index.md already exists", async () => {
+  const dir = join(root, "antigravity")
+  await mkdir(dir, { recursive: true })
+  writeFileSync(join(dir, "index.md"), "existing")
+  await expect(createPost(post, dir)).rejects.toThrow(/already exists/i)
+})
+
+test("createPost: throws when blogDir does not exist", async () => {
+  const dir = join(root, "missing")
+  await expect(createPost(post, dir)).rejects.toThrow(/ENOENT|no such file/i)
+})
+
+test("createPost: does not leave a .tmp file when the write succeeds", async () => {
+  const dir = join(root, "antigravity")
+  await mkdir(dir, { recursive: true })
+  await createPost(post, dir)
+  expect(() => statSync(join(dir, "index.md.tmp"))).toThrow()
+})
+
+test("createPost: title is JSON-quoted (handles embedded quotes)", async () => {
+  const dir = join(root, "quoted")
+  await mkdir(dir, { recursive: true })
+  const tricky = { ...post, title: 'Has "quotes" and \\backslash' }
+  await createPost(tricky, dir)
+  const out = readFileSync(join(dir, "index.md"), "utf8")
+  expect(out).toContain('title: "Has \\"quotes\\" and \\\\backslash"')
+})
+
+test("deletePost: removes the directory recursively", async () => {
+  const dir = join(root, "to-delete")
+  await mkdir(dir, { recursive: true })
+  writeFileSync(join(dir, "index.md"), "stuff")
+  writeFileSync(join(dir, "image.png"), "binary")
+  await deletePost(dir)
+  expect(() => statSync(dir)).toThrow()
+})
+
+test("deletePost: ENOENT is a no-op (idempotent)", async () => {
+  const dir = join(root, "never-existed")
+  await expect(deletePost(dir)).resolves.toBeUndefined()
 })

--- a/lib/sync/fs-writer.ts
+++ b/lib/sync/fs-writer.ts
@@ -1,4 +1,11 @@
-import { readFile, rename, unlink, writeFile } from "node:fs/promises"
+import {
+  access,
+  readFile,
+  rename,
+  rm,
+  unlink,
+  writeFile,
+} from "node:fs/promises"
 import { join } from "node:path"
 import type { Post } from "./types"
 
@@ -47,4 +54,40 @@ export async function updatePost(post: Post, blogDir: string): Promise<void> {
     await unlink(tmp).catch(() => {})
     throw err
   }
+}
+
+function renderNewIndex(post: Post): string {
+  const fm = [
+    `title: ${JSON.stringify(post.title)}`,
+    `created_at: '${post.createdAt.toISOString()}'`,
+    `updated_at: '${post.updatedAt.toISOString()}'`,
+    `cosense_id: ${post.id}`,
+  ].join("\n")
+  const body = post.body.endsWith("\n") ? post.body : `${post.body}\n`
+  return `---\n${fm}\n---\n\n${body}`
+}
+
+export async function createPost(post: Post, blogDir: string): Promise<void> {
+  // blogDir must already exist (orchestrator's job); ENOENT surfaces
+  // through the writeFile below if it does not.
+  const indexPath = join(blogDir, "index.md")
+  // index.md must NOT exist; throw a clear message if it does.
+  try {
+    await access(indexPath)
+    throw new Error(`index.md already exists at ${indexPath}`)
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err
+  }
+  const tmp = `${indexPath}.tmp`
+  await writeFile(tmp, renderNewIndex(post))
+  try {
+    await rename(tmp, indexPath)
+  } catch (err) {
+    await unlink(tmp).catch(() => {})
+    throw err
+  }
+}
+
+export async function deletePost(blogDir: string): Promise<void> {
+  await rm(blogDir, { recursive: true, force: true })
 }

--- a/lib/sync/slug.test.ts
+++ b/lib/sync/slug.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "vitest"
-import { isValidSlug, slugForPageId } from "./slug"
+import { isValidSlug, slugForPageId, slugForTitle } from "./slug"
 
 test("page id passes through verbatim", () => {
   expect(slugForPageId("0123456789abcdef01234567")).toBe(
@@ -14,6 +14,56 @@ test("rejects non-id input", () => {
 
 test("slugForPageId throws with descriptive message on invalid input", () => {
   expect(() => slugForPageId("not-a-page-id")).toThrow(
+    /invalid Cosense page id/,
+  )
+})
+
+test("slugForTitle: ASCII title becomes lowercase kebab-case", () => {
+  expect(slugForTitle("Awesome Feature", "0123456789abcdef01234567")).toBe(
+    "awesome-feature",
+  )
+})
+
+test("slugForTitle: collapses runs of whitespace and dashes", () => {
+  expect(
+    slugForTitle("Hello   World---thing", "0123456789abcdef01234567"),
+  ).toBe("hello-world-thing")
+})
+
+test("slugForTitle: strips punctuation that is not a dash", () => {
+  expect(slugForTitle("Don't break, please!", "0123456789abcdef01234567")).toBe(
+    "dont-break-please",
+  )
+})
+
+test("slugForTitle: trims leading and trailing dashes", () => {
+  expect(slugForTitle("--- foo ---", "0123456789abcdef01234567")).toBe("foo")
+})
+
+test("slugForTitle: pure-CJK title falls back to page id", () => {
+  expect(slugForTitle("買ってよかったもの", "0123456789abcdef01234567")).toBe(
+    "0123456789abcdef01234567",
+  )
+})
+
+test("slugForTitle: title that slugifies to under 3 chars falls back to page id", () => {
+  expect(slugForTitle("a!", "0123456789abcdef01234567")).toBe(
+    "0123456789abcdef01234567",
+  )
+})
+
+test("slugForTitle: numeric-only title is kept when long enough", () => {
+  expect(slugForTitle("2026", "0123456789abcdef01234567")).toBe("2026")
+})
+
+test("slugForTitle: mixed CJK + ASCII keeps the ASCII portion when long enough", () => {
+  expect(
+    slugForTitle("買ってよかったもの 2025 review", "0123456789abcdef01234567"),
+  ).toBe("2025-review")
+})
+
+test("slugForTitle: rejects an invalid page id", () => {
+  expect(() => slugForTitle("Anything", "not-a-page-id")).toThrow(
     /invalid Cosense page id/,
   )
 })

--- a/lib/sync/slug.ts
+++ b/lib/sync/slug.ts
@@ -10,3 +10,17 @@ export function slugForPageId(pageId: string): string {
 export function isValidSlug(s: string): boolean {
   return PAGE_ID_RE.test(s)
 }
+
+export function slugForTitle(title: string, pageId: string): string {
+  if (!PAGE_ID_RE.test(pageId)) {
+    throw new Error(`invalid Cosense page id: ${pageId}`)
+  }
+  const slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+  if (slug.length >= 3) return slug
+  return pageId
+}

--- a/lib/sync/types.ts
+++ b/lib/sync/types.ts
@@ -55,12 +55,25 @@ export interface ImageRef {
 
 /** Output of diff stage. */
 export type SyncAction =
+  | { kind: "create"; page: CosenseListEntry; slug: string }
   | { kind: "update"; page: CosenseListEntry; blogDir: string }
   | { kind: "unchanged"; id: string }
-  | { kind: "skip"; title: string; reason: "no-stub" }
+  | { kind: "delete"; blogDir: string; cosenseId: string }
 
 export interface SyncPlan {
   actions: SyncAction[]
   /** Number of stub directories scanned in `content/posts/`. */
   stubCount: number
+}
+
+/**
+ * Thrown by the sync orchestrator when the count or ratio of `delete` actions
+ * in a single run exceeds configured thresholds. Treated as a workflow
+ * crash by Phase 3's health reporter (which opens a `sync-broken` issue).
+ */
+export class DeleteThresholdError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "DeleteThresholdError"
+  }
 }

--- a/scripts/sync-cosense.test.ts
+++ b/scripts/sync-cosense.test.ts
@@ -117,7 +117,7 @@ test("real run updates matched stubs into their existing dirs", async () => {
   expect(aOut).not.toContain("old body")
 })
 
-test("Cosense pages with no matching stub are skipped without error", async () => {
+test("Cosense pages with no matching stub become create actions without error", async () => {
   await makeStub("a-stub", "A")
   // no stub for B
   const c = stubClient()
@@ -128,8 +128,8 @@ test("Cosense pages with no matching stub are skipped without error", async () =
     dryRun: false,
   })
   const kinds = r.plan.actions.map((a) => a.kind).sort()
-  expect(kinds).toEqual(["skip", "update"])
-  expect(c.getPage).toHaveBeenCalledTimes(1) // only A was fetched
+  expect(kinds).toEqual(["create", "update"])
+  expect(c.getPage).toHaveBeenCalledTimes(1) // only A was fetched (create not yet implemented in orchestrator)
   expect(r.errors).toHaveLength(0)
 })
 

--- a/scripts/sync-cosense.test.ts
+++ b/scripts/sync-cosense.test.ts
@@ -11,6 +11,7 @@ import { mkdir } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, expect, test, vi } from "vitest"
+import { DeleteThresholdError } from "@/lib/sync/types"
 import { runSync } from "./sync-cosense"
 
 let root: string
@@ -129,7 +130,7 @@ test("Cosense pages with no matching stub become create actions without error", 
   })
   const kinds = r.plan.actions.map((a) => a.kind).sort()
   expect(kinds).toEqual(["create", "update"])
-  expect(c.getPage).toHaveBeenCalledTimes(1) // only A was fetched (create not yet implemented in orchestrator)
+  expect(c.getPage).toHaveBeenCalledTimes(2) // A (update) and B (create) are both fetched
   expect(r.errors).toHaveLength(0)
 })
 
@@ -216,4 +217,229 @@ test("duplicate stub titles abort the whole run", async () => {
       dryRun: false,
     }),
   ).rejects.toThrow(/duplicate stub title/i)
+})
+
+test("create: new Cosense page produces a stub directory with frontmatter and body", async () => {
+  // No local stubs, two remote pages -> two creates.
+  const fetchStub = vi
+    .fn()
+    .mockResolvedValue(new Response(new Uint8Array([1]), { status: 200 }))
+  const r = await runSync({
+    client: stubClient(),
+    postsRoot,
+    errorsPath,
+    dryRun: false,
+    fetch: fetchStub,
+  })
+  expect(r.errors).toHaveLength(0)
+  expect(r.plan.actions.map((a) => a.kind).sort()).toEqual(["create", "create"])
+  // Slugs are "a" and "b" -> length-1, falls back to page id
+  const dirs = readdirSync(postsRoot).sort()
+  expect(dirs).toEqual(["0123456789abcdef01234567", "fedcba9876543210fedcba98"])
+  const aOut = readFileSync(
+    join(postsRoot, "0123456789abcdef01234567", "index.md"),
+    "utf8",
+  )
+  expect(aOut).toContain('title: "A"')
+  expect(aOut).toContain("cosense_id: 0123456789abcdef01234567")
+  expect(aOut).toContain("Synced body line.")
+})
+
+test("create: ASCII title with sufficient length keeps the title slug", async () => {
+  const remoteAntigrav = {
+    count: 1,
+    pages: [
+      {
+        id: "1111111111111111111111aa",
+        title: "Antigravity",
+        updated: 2_000_000_000,
+      },
+    ],
+  }
+  const c = {
+    listPages: vi.fn().mockResolvedValue(remoteAntigrav),
+    getPage: vi
+      .fn()
+      .mockResolvedValue(detailFor("1111111111111111111111aa", "Antigravity")),
+  }
+  await runSync({
+    client: c,
+    postsRoot,
+    errorsPath,
+    dryRun: false,
+    fetch: vi
+      .fn()
+      .mockResolvedValue(new Response(new Uint8Array([1]), { status: 200 })),
+  })
+  expect(readdirSync(postsRoot)).toEqual(["antigravity"])
+})
+
+test("create: slug collision with a legacy stub appends a 6-hex suffix", async () => {
+  // A pre-existing legacy stub at "antigravity" with NO cosense_id.
+  await mkdir(join(postsRoot, "antigravity"), { recursive: true })
+  writeFileSync(
+    join(postsRoot, "antigravity", "index.md"),
+    "---\ntitle: 'Antigravity (legacy)'\n---\n\nlegacy body\n",
+  )
+  const remoteAntigrav = {
+    count: 1,
+    pages: [
+      {
+        id: "1111111111111111111111aa",
+        title: "Antigravity",
+        updated: 2_000_000_000,
+      },
+    ],
+  }
+  const c = {
+    listPages: vi.fn().mockResolvedValue(remoteAntigrav),
+    getPage: vi
+      .fn()
+      .mockResolvedValue(detailFor("1111111111111111111111aa", "Antigravity")),
+  }
+  await runSync({
+    client: c,
+    postsRoot,
+    errorsPath,
+    dryRun: false,
+    fetch: vi
+      .fn()
+      .mockResolvedValue(new Response(new Uint8Array([1]), { status: 200 })),
+  })
+  // Legacy is untouched; new stub gets the suffix from the first 6 hex
+  // chars of the page id (1111111111111111111111aa -> 111111).
+  const dirs = readdirSync(postsRoot).sort()
+  expect(dirs).toEqual(["antigravity", "antigravity-111111"])
+  expect(
+    readFileSync(join(postsRoot, "antigravity", "index.md"), "utf8"),
+  ).toContain("legacy body")
+  expect(
+    readFileSync(join(postsRoot, "antigravity-111111", "index.md"), "utf8"),
+  ).toContain("cosense_id: 1111111111111111111111aa")
+})
+
+test("delete: stub with cosense_id absent from remote is removed", async () => {
+  // Pre-existing stub with cosense_id that no longer matches any remote.
+  await makeStub(
+    "going-away",
+    "Going Away",
+    "2020-01-01T00:00:00.000Z",
+    "999999999999999999999999",
+  )
+  // Pre-existing stub for "A" so the run is not just deletes
+  await makeStub("a-stub", "A")
+  // Legacy stub WITHOUT cosense_id -> must survive
+  await makeStub("legacy", "Legacy Untouched")
+  const r = await runSync({
+    client: stubClient({
+      // remote only has A and B; "Going Away" disappeared
+    }),
+    postsRoot,
+    errorsPath,
+    dryRun: false,
+    fetch: vi
+      .fn()
+      .mockResolvedValue(new Response(new Uint8Array([1]), { status: 200 })),
+  })
+  expect(r.errors).toHaveLength(0)
+  const dirs = readdirSync(postsRoot).sort()
+  // a-stub remains (updated), going-away removed, legacy preserved,
+  // "fedcba9876543210fedcba98" created for B
+  expect(dirs).toEqual(["a-stub", "fedcba9876543210fedcba98", "legacy"])
+})
+
+test("delete: legacy stub (no cosense_id) is never deleted even with no remote match", async () => {
+  await makeStub("legacy", "Legacy Untouched")
+  const c = {
+    listPages: vi.fn().mockResolvedValue({ count: 0, pages: [] }),
+    getPage: vi.fn(),
+  }
+  // count=0, ratio=0 -> thresholds pass; no deletes (legacy has no cosense_id)
+  const r = await runSync({
+    client: c,
+    postsRoot,
+    errorsPath,
+    dryRun: false,
+  })
+  expect(r.plan.actions).toHaveLength(0)
+  expect(readdirSync(postsRoot)).toEqual(["legacy"])
+})
+
+test("threshold: absolute count violation throws DeleteThresholdError before any deletes", async () => {
+  // Six stubs with cosense_id, none in remote -> 6 deletes -> exceeds default 5.
+  for (let i = 0; i < 6; i++) {
+    await makeStub(
+      `gone-${i}`,
+      `Gone ${i}`,
+      "2020-01-01T00:00:00.000Z",
+      `aaaaaaaaaaaaaaaaaaaaaa${i.toString().padStart(2, "0")}`,
+    )
+  }
+  const c = {
+    listPages: vi.fn().mockResolvedValue({ count: 0, pages: [] }),
+    getPage: vi.fn(),
+  }
+  await expect(
+    runSync({
+      client: c,
+      postsRoot,
+      errorsPath,
+      dryRun: false,
+      maxDeleteAbs: 5,
+      maxDeleteRatio: 1.0, // disable ratio gate
+    }),
+  ).rejects.toBeInstanceOf(DeleteThresholdError)
+  // No directory was deleted
+  expect(readdirSync(postsRoot).length).toBe(6)
+})
+
+test("threshold: ratio violation throws DeleteThresholdError", async () => {
+  // 4 stubs, all with cosense_id, none in remote -> ratio 1.0 > 0.05.
+  for (let i = 0; i < 4; i++) {
+    await makeStub(
+      `gone-${i}`,
+      `Gone ${i}`,
+      "2020-01-01T00:00:00.000Z",
+      `bbbbbbbbbbbbbbbbbbbbbb${i.toString().padStart(2, "0")}`,
+    )
+  }
+  const c = {
+    listPages: vi.fn().mockResolvedValue({ count: 0, pages: [] }),
+    getPage: vi.fn(),
+  }
+  await expect(
+    runSync({
+      client: c,
+      postsRoot,
+      errorsPath,
+      dryRun: false,
+      maxDeleteAbs: 100, // disable absolute gate
+      maxDeleteRatio: 0.05,
+    }),
+  ).rejects.toBeInstanceOf(DeleteThresholdError)
+})
+
+test("threshold: a single legitimate delete passes the default 5 / 0.05 thresholds", async () => {
+  // 1 cosense-sourced stub absent from remote, 19 still matching -> ratio 0.05.
+  await makeStub(
+    "gone",
+    "Gone",
+    "2020-01-01T00:00:00.000Z",
+    "999999999999999999999999",
+  )
+  // 19 stubs whose titles match nothing in remote (no-op for them) is verbose;
+  // simpler: rely on the absolute gate. With 1 delete and default abs=5, pass.
+  const c = {
+    listPages: vi.fn().mockResolvedValue({ count: 0, pages: [] }),
+    getPage: vi.fn(),
+  }
+  await runSync({
+    client: c,
+    postsRoot,
+    errorsPath,
+    dryRun: false,
+    // ratio 1/1 = 1.0 -> would fail default ratio. Override to disable.
+    maxDeleteRatio: 1.0,
+  })
+  expect(readdirSync(postsRoot)).toEqual([])
 })

--- a/scripts/sync-cosense.test.ts
+++ b/scripts/sync-cosense.test.ts
@@ -340,6 +340,10 @@ test("delete: stub with cosense_id absent from remote is removed", async () => {
     fetch: vi
       .fn()
       .mockResolvedValue(new Response(new Uint8Array([1]), { status: 200 })),
+    // 1 delete / 1 cosense-sourced stub = ratio 1.0 in this tiny fixture.
+    // Production has ~50 stubs so a single delete is ~0.02. Disable the
+    // ratio gate here to exercise basic delete behaviour, not threshold tuning.
+    maxDeleteRatio: 1.0,
   })
   expect(r.errors).toHaveLength(0)
   const dirs = readdirSync(postsRoot).sort()

--- a/scripts/sync-cosense.ts
+++ b/scripts/sync-cosense.ts
@@ -1,18 +1,20 @@
 // scripts/sync-cosense.ts
-import { readdir, readFile, writeFile } from "node:fs/promises"
+import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises"
 import { join, resolve } from "node:path"
 import { z } from "zod"
 import { CosenseClient } from "@/lib/sync/cosense-client"
 import { computePlan, type LocalPostState } from "@/lib/sync/diff"
-import { updatePost } from "@/lib/sync/fs-writer"
+import { createPost, deletePost, updatePost } from "@/lib/sync/fs-writer"
 import { downloadImages } from "@/lib/sync/images"
 import { parseFrontmatter } from "@/lib/sync/parse-frontmatter"
 import { transformPage } from "@/lib/sync/transform"
-import type { SyncPlan } from "@/lib/sync/types"
+import { DeleteThresholdError, type SyncPlan } from "@/lib/sync/types"
 
 const envSchema = z.object({
   COSENSE_PROJECT: z.string().min(1),
   COSENSE_SID: z.string().min(1),
+  MAX_DELETE_ABS: z.coerce.number().int().nonnegative().default(5),
+  MAX_DELETE_RATIO: z.coerce.number().nonnegative().default(1.0),
 })
 
 const POSTS_ROOT = resolve(process.cwd(), "content/posts")
@@ -40,11 +42,36 @@ export interface RunOptions {
   errorsPath: string
   dryRun: boolean
   fetch?: typeof globalThis.fetch
+  maxDeleteAbs?: number
+  maxDeleteRatio?: number
 }
 
 export interface RunResult {
   plan: SyncPlan
   errors: SyncError[]
+}
+
+async function dirExists(p: string): Promise<boolean> {
+  try {
+    await stat(p)
+    return true
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return false
+    throw err
+  }
+}
+
+async function resolveCreateSlug(
+  postsRoot: string,
+  preferredSlug: string,
+  pageId: string,
+): Promise<string> {
+  if (!(await dirExists(join(postsRoot, preferredSlug)))) return preferredSlug
+  const withSuffix = `${preferredSlug}-${pageId.slice(0, 6)}`
+  if (!(await dirExists(join(postsRoot, withSuffix)))) return withSuffix
+  throw new Error(
+    `slug collision: both ${preferredSlug}/ and ${withSuffix}/ already exist`,
+  )
 }
 
 export async function runSync(opts: RunOptions): Promise<RunResult> {
@@ -54,18 +81,68 @@ export async function runSync(opts: RunOptions): Promise<RunResult> {
 
   if (opts.dryRun) return { plan, errors: [] }
 
+  // --- Threshold check (BEFORE any side effects) ---
+  const maxAbs = opts.maxDeleteAbs ?? 5
+  const maxRatio = opts.maxDeleteRatio ?? 1.0
+  const deleteCount = plan.actions.filter((a) => a.kind === "delete").length
+  const cosenseSourced = local.filter((s) => s.cosenseId).length
+  const ratio = cosenseSourced > 0 ? deleteCount / cosenseSourced : 0
+  if (deleteCount > maxAbs) {
+    throw new DeleteThresholdError(
+      `delete count ${deleteCount} exceeds MAX_DELETE_ABS=${maxAbs}`,
+    )
+  }
+  if (ratio > maxRatio) {
+    throw new DeleteThresholdError(
+      `delete ratio ${ratio.toFixed(3)} exceeds MAX_DELETE_RATIO=${maxRatio.toFixed(3)}`,
+    )
+  }
+
+  // Ensure postsRoot exists before any create actions.
+  await mkdir(opts.postsRoot, { recursive: true })
+
   const errors: SyncError[] = []
   for (const action of plan.actions) {
-    if (action.kind !== "update") continue
     try {
-      const page = await opts.client.getPage(action.page.title)
-      const post = transformPage(page)
-      const dir = join(opts.postsRoot, action.blogDir)
-      await downloadImages(post.images, dir, { fetch: opts.fetch })
-      await updatePost(post, dir)
+      if (action.kind === "update") {
+        const page = await opts.client.getPage(action.page.title)
+        const post = transformPage(page)
+        const dir = join(opts.postsRoot, action.blogDir)
+        await downloadImages(post.images, dir, { fetch: opts.fetch })
+        await updatePost(post, dir)
+      } else if (action.kind === "create") {
+        const page = await opts.client.getPage(action.page.title)
+        const post = transformPage(page)
+        const finalSlug = await resolveCreateSlug(
+          opts.postsRoot,
+          action.slug,
+          page.id,
+        )
+        const dir = join(opts.postsRoot, finalSlug)
+        await mkdir(dir, { recursive: false })
+        try {
+          await downloadImages(post.images, dir, { fetch: opts.fetch })
+          await createPost(post, dir)
+        } catch (innerErr) {
+          // Rollback an empty/partial dir so the next tick is clean.
+          await deletePost(dir).catch(() => {})
+          throw innerErr
+        }
+      } else if (action.kind === "delete") {
+        await deletePost(join(opts.postsRoot, action.blogDir))
+      }
+      // unchanged: nothing to do
     } catch (err) {
+      let title: string
+      if (action.kind === "delete") {
+        title = `(delete cosense_id ${action.cosenseId})`
+      } else if (action.kind === "create" || action.kind === "update") {
+        title = action.page.title
+      } else {
+        title = `(unknown action: ${action.kind})`
+      }
       errors.push({
-        title: action.page.title,
+        title,
         error: err instanceof Error ? err.message : String(err),
       })
     }
@@ -106,15 +183,17 @@ async function readLocalStateAt(postsRoot: string): Promise<LocalPostState[]> {
 }
 
 function summarise(plan: SyncPlan, errors: SyncError[]): string {
+  let create = 0
   let update = 0
   let unchanged = 0
-  let skip = 0
+  let del = 0
   for (const a of plan.actions) {
-    if (a.kind === "update") update++
+    if (a.kind === "create") create++
+    else if (a.kind === "update") update++
     else if (a.kind === "unchanged") unchanged++
-    else skip++
+    else if (a.kind === "delete") del++
   }
-  return `plan: ${update} update, ${unchanged} unchanged, ${skip} skip(no-stub), ${errors.length} errors (stubs: ${plan.stubCount})`
+  return `plan: ${create} create, ${update} update, ${unchanged} unchanged, ${del} delete, ${errors.length} errors (stubs: ${plan.stubCount})`
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
@@ -128,6 +207,8 @@ if (import.meta.url === `file://${process.argv[1]}`) {
     postsRoot: POSTS_ROOT,
     errorsPath: ERRORS_PATH,
     dryRun: args.dryRun,
+    maxDeleteAbs: env.MAX_DELETE_ABS,
+    maxDeleteRatio: env.MAX_DELETE_RATIO,
   })
     .then(async ({ plan, errors }) => {
       console.log(summarise(plan, errors))

--- a/scripts/sync-cosense.ts
+++ b/scripts/sync-cosense.ts
@@ -14,7 +14,7 @@ const envSchema = z.object({
   COSENSE_PROJECT: z.string().min(1),
   COSENSE_SID: z.string().min(1),
   MAX_DELETE_ABS: z.coerce.number().int().nonnegative().default(5),
-  MAX_DELETE_RATIO: z.coerce.number().nonnegative().default(1.0),
+  MAX_DELETE_RATIO: z.coerce.number().nonnegative().default(0.05),
 })
 
 const POSTS_ROOT = resolve(process.cwd(), "content/posts")
@@ -83,7 +83,7 @@ export async function runSync(opts: RunOptions): Promise<RunResult> {
 
   // --- Threshold check (BEFORE any side effects) ---
   const maxAbs = opts.maxDeleteAbs ?? 5
-  const maxRatio = opts.maxDeleteRatio ?? 1.0
+  const maxRatio = opts.maxDeleteRatio ?? 0.05
   const deleteCount = plan.actions.filter((a) => a.kind === "delete").length
   const cosenseSourced = local.filter((s) => s.cosenseId).length
   const ratio = cosenseSourced > 0 ? deleteCount / cosenseSourced : 0


### PR DESCRIPTION
## Summary

Reverses Phase 2's opt-in stub model for Cosense-sourced posts: new Cosense pages auto-publish, deleted Cosense pages auto-remove the matching blog directory, and 61 legacy hand-authored posts (without \`cosense_id\`) stay untouched.

- New \`SyncAction\` variants \`create\` / \`delete\` (Phase 2's \`skip\` is removed). Diff stage emits them; orchestrator dispatches them.
- New \`slugForTitle(title, pageId)\` — ASCII-slugify with page-id fallback for non-ASCII / under-3-char titles.
- New \`createPost\` (atomic write with full frontmatter) and \`deletePost\` (idempotent recursive rm) in \`fs-writer\`.
- Two-threshold delete cap: \`MAX_DELETE_ABS=5\` and \`MAX_DELETE_RATIO=0.05\`. Either trips → orchestrator throws \`DeleteThresholdError\` BEFORE any side effects → Phase 3's reporter opens a \`sync-broken\` issue.
- Slug-collision resolution at apply time (suffix with first 6 hex of page id; double-collision throws).
- Per-page error tolerance applies to all action kinds; failures land in \`.sync-errors.json\`.
- Legacy posts (no \`cosense_id\`) are structurally invisible to the delete pass.

Spec: \`docs/superpowers/specs/2026-05-04-cosense-phase-4-design.md\`
Plan: \`docs/superpowers/plans/2026-05-04-cosense-sync-phase-4.md\`

## Migration

First sync run after merge will:
- Update bodies for the 48 currently-matched posts (no slug change).
- Auto-create 3 new posts: \`Antigravity\`, \`clay\`, \`kashitaka\`. \`created_at\` taken from each Cosense page; \`cosense_id\` stamped.
- Delete 0 posts (no Cosense page is missing relative to existing stubs).
- Leave the 61 legacy posts untouched.

No manual ops required before merge — the workflow already passes \`MAX_DELETE_ABS=5\` and \`MAX_DELETE_RATIO=0.05\` via env, and Phase 3's \`sync-broken\` label is already in place.

## Test plan

- [ ] After merge, the next cron tick (within 30 minutes) creates the 3 expected posts and reports \`sync-report-health: noop\`.
- [ ] No \`sync-broken\` issue is opened on the green path.
- [ ] (Optional) Delete-propagation smoke test: rename or temporarily delete one Cosense page, observe the corresponding blog directory disappearing on the next tick (or reappearing on restoration). Both threshold defaults (\`5\` absolute, \`5%\` ratio) make a single-page deletion pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)