### PR TITLE
Fix sync workflow observability: report on whole-job health

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -26,7 +26,6 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Run sync
         id: sync
-        continue-on-error: true
         run: pnpm sync ${{ inputs.dry_run && '--dry-run' || '' }}
         env:
           COSENSE_PROJECT:  ${{ secrets.COSENSE_PROJECT }}
@@ -34,7 +33,7 @@ jobs:
           MAX_DELETE_ABS:   '5'
           MAX_DELETE_RATIO: '0.05'
       - name: Commit & push (skipped on dry-run)
-        if: ${{ !inputs.dry_run }}
+        if: ${{ !inputs.dry_run && success() }}
         run: |
           if [ -n "$(git status --porcelain content)" ]; then
             git config user.name  "blog-sync[bot]"
@@ -64,11 +63,7 @@ jobs:
       - name: Report sync health
         if: ${{ always() && !inputs.dry_run }}
         env:
-          SYNC_STATUS: ${{ steps.sync.outcome }}
+          SYNC_STATUS: ${{ job.status == 'success' && 'success' || 'failure' }}
           WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm sync:report-health
-
-      - name: Fail job if sync failed
-        if: ${{ steps.sync.outcome == 'failure' }}
-        run: exit 1


### PR DESCRIPTION
## Summary

Phase 4's first production run (commit \`9617edc\`, run 25333127322) revealed an observability gap: the sync engine succeeded and produced 3 new posts (Antigravity / clay / kashitaka), but \`Commit & push\` failed because branch protection rejected the direct push. Phase 3's reporter then logged \`sync-report-health: noop\` because it only inspected \`steps.sync.outcome\`. No \`sync-broken\` issue was opened. Silent failure for ~1.5 hours.

This change makes the reporter consider the whole job's health.

## Changes

- Drop \`continue-on-error: true\` from \`Run sync\`. Sync failures now naturally fail the job.
- Drop the trailing \`Fail job if sync failed\` compensating step. No longer needed.
- Add \`success()\` to the \`Commit & push\` if-condition so it correctly skips on a prior sync failure.
- Change the reporter's \`SYNC_STATUS\` env from \`steps.sync.outcome\` to \`job.status == 'success' && 'success' || 'failure'\`. This captures any unmasked failure in any prior step.

The reporter's TS code and tests are unchanged — its env contract still receives \`success | failure\`, just with broader semantics.

## Test plan

- [ ] After merge, the next cron tick triggers a green run; reporter still logs \`sync-report-health: noop\`.
- [ ] (Optional smoke test) Manually break a downstream step (e.g. revoke push permission temporarily, or trigger \`workflow_dispatch\` on a branch where commit will fail) and confirm a \`sync-broken\` issue is opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)