### PR TITLE
fix(sync): fetch Gyazo images from i.gyazo.com CDN

### DIFF
--- a/lib/sync/transform.test.ts
+++ b/lib/sync/transform.test.ts
@@ -39,7 +39,10 @@ test("strips title line and emits IR", () => {
   expect(post.body).toContain("Intro paragraph.")
   expect(post.body).not.toContain("First Post\n")
   expect(post.images).toEqual([
-    { url: "https://gyazo.com/ABCDEF123456.png", filename: "ABCDEF123456.png" },
+    {
+      url: "https://i.gyazo.com/ABCDEF123456.png",
+      filename: "ABCDEF123456.png",
+    },
   ])
 })
 

--- a/lib/sync/transform.ts
+++ b/lib/sync/transform.ts
@@ -18,8 +18,10 @@ function extractImages(text: string): ImageRef[] {
   const out: ImageRef[] = []
   for (const m of text.matchAll(GYAZO_RE)) {
     const ext = m[2] ?? ".png"
+    // The raw image lives on the i.gyazo.com CDN; gyazo.com/<id>.png is the
+    // permalink page and 404s when fetched as an image.
     out.push({
-      url: `https://gyazo.com/${m[1]}${ext}`,
+      url: `https://i.gyazo.com/${m[1]}${ext}`,
       filename: `${m[1]}${ext}`,
     })
   }


### PR DESCRIPTION
## 概要

Cosense からの sync で、Gyazo 画像を含む記事が無言で同期失敗していた問題を修正します。

## 何が起きていたか

ジョブ自体は成功(緑)でしたが、記事がコミットされていませんでした。自動で立った Issue #715 に実エラーが残っていました:

```
ESP-Claw を触ってみている — image fetch https://gyazo.com/c9d9295a3f96ff950d3beaf693250b13.png -> 404
```

### 流れ
1. 記事が Gyazo 画像を含む
2. sync が `https://gyazo.com/<id>.png` を取得 → **404**
3. `downloadImages` が throw → create が `deletePost` でロールバック (`sync-cosense.ts`)
4. content に変更が残らない → commit ステップの `git status --porcelain content` が空 → コミットされず
5. per-page エラーはジョブを落とさない設計なので job は success のまま。`sync-report-health` だけが `sync-broken` Issue を立てて知らせていた

## 根本原因と修正

`lib/sync/transform.ts` が Gyazo の**ページURL** (`gyazo.com/<id>.png`) を画像として叩いていました。画像実体は CDN の `i.gyazo.com` 配信です。本番初の Gyazo 画像付き記事だったため(既存記事に gyazo 画像なし)、これまで顕在化していませんでした。

```diff
- url: `https://gyazo.com/${m[1]}${ext}`,
+ url: `https://i.gyazo.com/${m[1]}${ext}`,
```

`filename` は不変 (`<id>.png`) なので本文 markdown の参照とも整合します。

## 検証
- ユニットテスト 119件 pass
- `lint:ci` pass
- 型チェックのエラーは生成物 (`routeTree.gen.ts` / `.velite`) 未生成による既知の事象で、本変更とは無関係

マージ後、次の cron で記事が `content/posts/` に作成・コミットされ、Issue #715 も自動クローズされます。

Closes #715

https://claude.ai/code/session_01VahwNfFnsW99x8Xt1kKTot

---
_Generated by [Claude Code](https://claude.ai/code/session_01VahwNfFnsW99x8Xt1kKTot)_