### PR TITLE
fix(sync): fetch Gyazo images via /raw to handle non-PNG uploads

### DIFF
--- a/lib/sync/transform.test.ts
+++ b/lib/sync/transform.test.ts
@@ -40,7 +40,7 @@ test("strips title line and emits IR", () => {
   expect(post.body).not.toContain("First Post\n")
   expect(post.images).toEqual([
     {
-      url: "https://i.gyazo.com/ABCDEF123456.png",
+      url: "https://gyazo.com/ABCDEF123456/raw",
       filename: "ABCDEF123456.png",
     },
   ])

--- a/lib/sync/transform.ts
+++ b/lib/sync/transform.ts
@@ -18,10 +18,11 @@ function extractImages(text: string): ImageRef[] {
   const out: ImageRef[] = []
   for (const m of text.matchAll(GYAZO_RE)) {
     const ext = m[2] ?? ".png"
-    // The raw image lives on the i.gyazo.com CDN; gyazo.com/<id>.png is the
-    // permalink page and 404s when fetched as an image.
+    // Fetch via the format-agnostic /raw endpoint, which 302-redirects to the
+    // original image. Hard-coding an extension (gyazo.com/<id>.png or
+    // i.gyazo.com/<id>.png) 404s whenever the upload isn't actually a PNG.
     out.push({
-      url: `https://i.gyazo.com/${m[1]}${ext}`,
+      url: `https://gyazo.com/${m[1]}/raw`,
       filename: `${m[1]}${ext}`,
     })
   }


### PR DESCRIPTION
## 概要

前回の `i.gyazo.com` 修正後も同期が失敗していた件の追従修正です。

## 何が起きていたか

`gyazo.com/<id>.png` と `i.gyazo.com/<id>.png` の **両方が 404**（実ランナーログ / Issue #717）:

```
ESP-Claw を触ってみている — image fetch https://i.gyazo.com/c9d9295a3f96ff950d3beaf693250b13.png -> 404
```

`i.gyazo.com` は実拡張子と一致しないと 404 を返すため、対象画像が PNG ではない（JPEG/GIF 等）と判明。404（403ではない）が返っている＝画像自体は存在します。

## 修正

拡張子決め打ちをやめ、フォーマット非依存の `/raw` エンドポイント（原本へ 302 リダイレクト、`fetch` が追従）に切り替え:

```diff
- url: `https://i.gyazo.com/${m[1]}${ext}`,
+ url: `https://gyazo.com/${m[1]}/raw`,
```

ローカルファイル名は `<id>.png` のままなので本文 markdown の参照は不変です。

## 検証
- ユニットテスト pass
- 実 URL の到達確認はこの環境のネットワークポリシー（Gyazo が許可リスト外）＋Gyazo のボット対策で不可。最終確認は次のラン待ち。`/raw` は Gyazo の正規・フォーマット非依存エンドポイントのため、実拡張子に関わらず吸収できる想定。

Closes #717

https://claude.ai/code/session_01VahwNfFnsW99x8Xt1kKTot

---
_Generated by [Claude Code](https://claude.ai/code/session_01VahwNfFnsW99x8Xt1kKTot)_