### PR TITLE
fix(sync): convert Scrapbox indented lines to Markdown bullet lists

### DIFF
--- a/content/posts/esp-claw/index.md
+++ b/content/posts/esp-claw/index.md
@@ -7,21 +7,16 @@ cosense_id: 6a20ba0db14916af2bcb5407
 
 TL;DR:
 
- 最初はメリットがわからなかったけど、数日触って見方が変わった
-
- コスパ: OpenClaw でオーバースペックだった部分が ESP32 で安価に済む
-
- 将来性: ルールが書けない探索段階でこそ実行時判断が効く。書けるなら書いた方がいい
+- 最初はメリットがわからなかったけど、数日触って見方が変わった
+- コスパ: OpenClaw でオーバースペックだった部分が ESP32 で安価に済む
+- 将来性: ルールが書けない探索段階でこそ実行時判断が効く。書けるなら書いた方がいい
 
 使っているもの
 
- ESP-Claw: https://github.com/espressif/esp-claw
-
- ボード: M5Stack CoreS3
-
- LLM: Opus4.6
-
- MCP: Homeassistant
+- ESP-Claw: https://github.com/espressif/esp-claw
+- ボード: M5Stack CoreS3
+- LLM: Opus4.6
+- MCP: Homeassistant
 
 コスパ面
 

--- a/lib/sync/scrapbox-to-md.test.ts
+++ b/lib/sync/scrapbox-to-md.test.ts
@@ -27,6 +27,28 @@ describe("scrapboxToMarkdown", () => {
       "[https://example.com.]",
       "<https://example.com>.",
     ],
+    ["bulleted list", " item1\n item2", "- item1\n- item2"],
+    [
+      "nested list",
+      " parent\n  child\n   grandchild",
+      "- parent\n  - child\n    - grandchild",
+    ],
+    ["tab-indented list", "\titem1\n\titem2", "- item1\n- item2"],
+    [
+      "list item with inline notation",
+      " [https://example.com Example]",
+      "- [Example](https://example.com)",
+    ],
+    [
+      "paragraph followed by list",
+      "TL;DR:\n first\n second",
+      "TL;DR:\n\n- first\n- second",
+    ],
+    [
+      "lists separated by a plain line stay separate",
+      " a\nplain\n b",
+      "- a\n\nplain\n\n- b",
+    ],
   ]
   for (const [label, input, expected] of cases) {
     test(label, () => {

--- a/lib/sync/scrapbox-to-md.ts
+++ b/lib/sync/scrapbox-to-md.ts
@@ -14,6 +14,7 @@ const URL_BARE_RE = /^\[(https?:\/\/[^\s\]]+?)([.,;:!?]?)\]$/
 const STAR_RE = /^\[(\*+)\s+(.+)\]$/
 const INTERNAL_RE = /^\[([^\]]+)\]$/
 const CODE_OPEN_RE = /^code:([^\s]+)$/
+const LIST_ITEM_RE = /^([ \t]+)(\S.*)$/
 
 function transformInline(line: string): string {
   // Whole-line wrappers handled first.
@@ -76,6 +77,22 @@ export function scrapboxToMarkdown(input: string): string {
         i++
       }
       blocks.push([`\`\`\`${ext}`, ...code, "```"].join("\n"))
+      continue
+    }
+    // Indented lines are Scrapbox bullet items (1 whitespace char per
+    // nesting level). Group consecutive items into one list block; depth
+    // maps to 2-space Markdown nesting so 4+ levels never become an
+    // indented code block.
+    if (LIST_ITEM_RE.test(raw)) {
+      const items: string[] = []
+      while (i < lines.length) {
+        const item = lines[i].match(LIST_ITEM_RE)
+        if (!item) break
+        const depth = item[1].length
+        items.push(`${"  ".repeat(depth - 1)}- ${transformInline(item[2])}`)
+        i++
+      }
+      blocks.push(items.join("\n"))
       continue
     }
     if (raw.trim() !== "") {


### PR DESCRIPTION
## Why

Reported example: https://scrapbox.io/jaxx2104/ESP-Claw_%E3%82%92%E8%A7%A6%E3%81%A3%E3%81%A6%E3%81%BF%E3%81%A6%E3%81%84%E3%82%8B vs https://jaxx2104.info/esp-claw

Indented lines in Cosense are bullet items (one whitespace char per nesting level), but `scrapboxToMarkdown` passed them through as plain blocks. Combined with the one-block-per-line paragraph join (#719), every list rendered as flat `<p>` paragraphs — the TL;DR items and the parts list on /esp-claw lost their list structure entirely.

## What

- Group consecutive indented lines into a single Markdown list block, applying `transformInline` per item
- Map Scrapbox depth (N whitespace chars) to 2-space Markdown nesting, so 4+ levels can never degrade into an indented code block
- Test rows added first per the translator's table-driven policy (bulleted / nested / tab-indented / inline-notation / paragraph+list / separated lists)
- Regenerate `content/posts/esp-claw/index.md` with the fixed translator, since sync skips pages whose Cosense `updated_at` is unchanged

## Verification

- `pnpm vitest run lib/sync` — 84 passed
- `pnpm test` (tsc) — clean after `pnpm build`
- `biome ci lib/sync content/posts/esp-claw` — clean
- Ran the fixed translator against the live Cosense page text; TL;DR and 使っているもの now emit `- ` lists, prose paragraphs and the Gyazo image unchanged
- Pre-existing textlint complaints on this post come from the Cosense prose itself, unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)