### PR TITLE
Refresh blog design: readable index cards, article typography, dark palette

### DIFF
--- a/app/routes/__root.tsx
+++ b/app/routes/__root.tsx
@@ -26,6 +26,7 @@ export const Route = createRootRoute({
       { property: "og:type", content: "website" },
       { property: "og:url", content: SITE_URL },
       { name: "twitter:card", content: "summary_large_image" },
+      { name: "theme-color", content: "#e91e63" },
     ],
     links: [
       {
@@ -53,7 +54,7 @@ export const Route = createRootRoute({
       },
       {
         rel: "stylesheet",
-        href: "https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;900&family=Permanent+Marker&display=swap",
+        href: "https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&family=Permanent+Marker&display=swap",
       },
       {
         rel: "alternate",

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -28,6 +28,7 @@ function HomePage() {
             key={post.permalink}
             path={post.permalink}
             title={post.title}
+            created_at={post.created_at}
             excerpt={post.excerpt}
             thumbnail={post.thumbnail}
           />

--- a/components/features/article/article-info.module.css
+++ b/components/features/article/article-info.module.css
@@ -15,5 +15,7 @@
 .meta {
   margin: 0.5rem 0;
   display: flex;
-  column-gap: 0.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
 }

--- a/components/features/article/article-tile.module.css
+++ b/components/features/article/article-tile.module.css
@@ -5,55 +5,69 @@
 .container {
   background: var(--color-background);
   border: 1px solid var(--color-border);
-  border-radius: 8px;
+  border-radius: var(--radius-m);
   overflow: hidden;
-  transition: all 0.2s ease-out;
-  aspect-ratio: 1;
+  transition:
+    border-color 0.2s ease-out,
+    box-shadow 0.2s ease-out,
+    transform 0.2s ease-out;
+  height: 100%;
   display: flex;
   flex-direction: column;
 }
 
 .container:hover {
+  border-color: var(--color-main);
   box-shadow: 0 4px 12px var(--color-shadow);
   transform: translateY(-2px);
 }
 
 .thumbnail {
   width: 100%;
-  height: auto;
+  aspect-ratio: 16 / 9;
   object-fit: cover;
+  border-bottom: 1px solid var(--color-border);
 }
 
 .content {
-  padding: 0.5rem;
+  padding: 0.75rem 1rem 1rem;
   flex: 1;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
+  gap: 0.5rem;
 }
 
 .title {
-  color: var(--color-main);
+  color: var(--color-title);
   font-size: var(--font-size);
   font-weight: var(--font-weight-bold);
-  line-height: 1.2;
-  letter-spacing: -0.025rem;
-  margin: 0 0 0.25rem 0;
+  font-feature-settings: "palt";
+  line-height: 1.5;
+  letter-spacing: 0.01em;
+  margin: 0;
   overflow: hidden;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
+  transition: color 0.2s ease-out;
+}
+
+.tileLink:hover .title {
+  color: var(--color-main);
 }
 
 .excerpt {
   font-size: var(--font-size-small);
   font-weight: var(--font-weight);
-  color: var(--color-text);
-  line-height: 1.4;
-  margin: 0 0 0.5rem 0;
+  color: var(--color-sub);
+  line-height: 1.6;
+  margin: 0;
   overflow: hidden;
   display: -webkit-box;
-  -webkit-line-clamp: 2;
+  -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
-  flex: 1;
+}
+
+.date {
+  margin-top: auto;
 }

--- a/components/features/article/article-tile.tsx
+++ b/components/features/article/article-tile.tsx
@@ -1,28 +1,40 @@
 import type React from "react"
+import Time from "@/components/ui/time"
 import Link from "@/lib/router-link"
 import styles from "./article-tile.module.css"
 
 interface Props {
   path: string
   title: string
+  created_at?: string
   excerpt?: string
   thumbnail?: string
 }
 
-const ArticleTile: React.FC<Props> = ({ path, title, excerpt, thumbnail }) => (
+const ArticleTile: React.FC<Props> = ({
+  path,
+  title,
+  created_at,
+  excerpt,
+  thumbnail,
+}) => (
   <Link href={path} className={styles.tileLink}>
     <article className={styles.container}>
+      {thumbnail && (
+        <img
+          className={styles.thumbnail}
+          src={thumbnail}
+          alt=""
+          loading="lazy"
+        />
+      )}
       <div className={styles.content}>
         <h2 className={styles.title}>{title}</h2>
-        {thumbnail ? (
-          <img
-            className={styles.thumbnail}
-            src={thumbnail}
-            alt={title}
-            loading="lazy"
-          />
-        ) : (
-          <p className={styles.excerpt}>{excerpt}</p>
+        {!thumbnail && excerpt && <p className={styles.excerpt}>{excerpt}</p>}
+        {created_at && (
+          <div className={styles.date}>
+            <Time created_at={created_at} />
+          </div>
         )}
       </div>
     </article>

--- a/components/features/article/article.tsx
+++ b/components/features/article/article.tsx
@@ -31,7 +31,7 @@ const Article: React.FC<Props> = ({
   site,
 }: Props) => {
   return (
-    <Container>
+    <Container narrow>
       <ArticleInfo
         path={path}
         title={title}

--- a/components/layout/footer.module.css
+++ b/components/layout/footer.module.css
@@ -1,3 +1,6 @@
 .footer {
-  padding: 2rem 0;
+  padding: 2rem 0 3rem;
+  text-align: center;
+  color: var(--color-sub);
+  font-size: var(--font-size-small);
 }

--- a/components/layout/navi-logo.module.css
+++ b/components/layout/navi-logo.module.css
@@ -6,9 +6,9 @@
   letter-spacing: -0.05rem;
   text-transform: uppercase;
   margin-right: 1rem;
+  transition: color 0.2s ease-out;
 }
 
 .logo:hover {
-  color: var(--color-accent);
-  transition: color 0.2s ease-out;
+  color: rgba(255, 255, 255, 0.75);
 }

--- a/components/layout/navi-menu.module.css
+++ b/components/layout/navi-menu.module.css
@@ -1,6 +1,7 @@
 .menu {
   display: flex;
   flex-direction: row;
+  align-items: center;
 }
 
 .item {
@@ -8,9 +9,9 @@
   cursor: pointer;
   margin-right: 1rem;
   font-size: var(--font-size);
+  transition: color 0.2s ease-out;
 }
 
 .item:hover {
-  color: var(--color-accent);
-  transition: color 0.2s ease-out;
+  color: rgba(255, 255, 255, 0.75);
 }

--- a/components/layout/navi.module.css
+++ b/components/layout/navi.module.css
@@ -1,9 +1,10 @@
 .header {
-  background-color: var(--color-main);
+  background-color: var(--color-brand);
   position: sticky;
-  margin-bottom: 1rem;
+  margin-bottom: 2rem;
   top: 0;
   z-index: 1;
+  box-shadow: 0 1px 4px var(--color-shadow);
 }
 
 .header a {

--- a/components/ui/badge.module.css
+++ b/components/ui/badge.module.css
@@ -1,20 +1,24 @@
 .badge {
-  background-color: var(--color-sub);
-  border-radius: 4px;
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
   box-sizing: border-box;
-  color: rgb(255, 255, 255);
-  display: inline;
+  color: var(--color-sub);
+  display: inline-block;
   font-size: var(--font-size-small);
-  line-height: var(--font-size-small);
+  line-height: 1;
   font-weight: var(--font-weight);
   outline-style: none;
   margin: auto 0;
   text-decoration-line: none;
-  padding: calc(var(--font-size-small) / 2) var(--font-size-small);
+  padding: 0.375em 0.875em;
   text-align: center;
   white-space: nowrap;
 }
 
 .badge[data-primary] {
-  background-color: var(--color-main);
+  background-color: var(--color-main-soft);
+  border-color: transparent;
+  color: var(--color-main);
+  font-weight: var(--font-weight-bold);
 }

--- a/components/ui/container.module.css
+++ b/components/ui/container.module.css
@@ -3,3 +3,7 @@
   padding: 0 1rem;
   max-width: var(--content-width);
 }
+
+.container[data-narrow] {
+  max-width: var(--content-width-narrow);
+}

--- a/components/ui/container.tsx
+++ b/components/ui/container.tsx
@@ -1,8 +1,15 @@
 import type React from "react"
 import styles from "./container.module.css"
 
-const Container: React.FC<{ children?: React.ReactNode }> = ({ children }) => (
-  <div className={styles.container}>{children}</div>
+interface Props {
+  children?: React.ReactNode
+  narrow?: boolean
+}
+
+const Container: React.FC<Props> = ({ children, narrow }) => (
+  <div className={styles.container} data-narrow={narrow ? "" : undefined}>
+    {children}
+  </div>
 )
 
 export default Container

--- a/components/ui/display.module.css
+++ b/components/ui/display.module.css
@@ -1,8 +1,9 @@
 .display {
   font-size: var(--display-size, var(--font-size-jumbo));
   font-weight: var(--font-weight-bold);
-  line-height: var(--font-size-large);
-  letter-spacing: -0.05rem;
+  line-height: var(--line-height-heading);
+  letter-spacing: 0.01em;
+  font-feature-settings: "palt";
   color: var(--color-main);
   padding: 0;
   text-transform: none;

--- a/components/ui/heading.module.css
+++ b/components/ui/heading.module.css
@@ -1,13 +1,14 @@
 .heading {
-  color: var(--color-main);
-  font-size: 1.5rem;
+  color: var(--color-title);
+  font-size: var(--font-size-h1);
   font-weight: var(--font-weight-bold);
-  letter-spacing: -0.025rem;
-  line-height: 1.2;
+  font-feature-settings: "palt";
+  letter-spacing: 0.01em;
+  line-height: var(--line-height-heading);
   margin: 0;
+  transition: color 0.2s ease-out;
 }
 
 .heading:hover {
-  transition: color 0.2s ease-out;
-  color: var(--color-sub);
+  color: var(--color-main);
 }

--- a/components/ui/section.module.css
+++ b/components/ui/section.module.css
@@ -13,7 +13,7 @@
 
 .section[data-variant="primary"] {
   color: white;
-  background: var(--color-main);
+  background: var(--color-brand);
 }
 
 .section[data-variant="dark"] {

--- a/components/ui/tile-grid.module.css
+++ b/components/ui/tile-grid.module.css
@@ -3,13 +3,18 @@
   padding: 0 1rem;
   max-width: var(--content-width);
   display: grid;
-  gap: 0.5rem;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
-  grid-auto-rows: auto;
+  gap: 1rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 @media (max-width: 767px) {
   .grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 519px) {
+  .grid {
+    grid-template-columns: minmax(0, 1fr);
   }
 }

--- a/styles/CLAUDE.md
+++ b/styles/CLAUDE.md
@@ -5,7 +5,10 @@
 ## Files
 
 ### `tokens.css` - Theme Tokens
-CSS custom properties (`--color-*` / `--font-size-*` / `--font-weight-*` / `--content-width` / `--line-height`) を `:root, [data-theme="light"]` と `[data-theme="dark"]` の 2 セットで定義する。コンポーネント側は `var(--color-main)` のように参照する。
+CSS custom properties (`--color-*` / `--font-size-*` / `--font-weight-*` / `--content-width` / `--content-width-narrow` / `--line-height*` / `--radius-*`) を `:root, [data-theme="light"]` と `[data-theme="dark"]` の 2 セットで定義する。コンポーネント側は `var(--color-main)` のように参照する。
+
+- `--color-main` はテーマごとのアクセント色（dark では明るいピンクに振る）。header などテーマに依らずブランドピンクで塗る面は `--color-brand` を使う
+- `--color-title` は見出し・強調テキスト、`--color-surface` はカード内・inline code・blockquote などの面に使う
 
 ### `global.css` - Global Styles
 `body` / `a` / `ul, ol, li` / 記事本文 (`.content` 配下の `h1-h6` / `p` / `blockquote` / `img` / `pre` / `code` / `.link-card*`) をスタイリングする。記事 HTML は Velite が生成した `dangerouslySetInnerHTML` 由来の DOM のため、Module ではなくグローバル CSS として当てる必要がある。

--- a/styles/global.css
+++ b/styles/global.css
@@ -11,18 +11,45 @@ body {
   line-height: var(--line-height);
 }
 
+::selection {
+  background-color: var(--color-main);
+  color: #ffffff;
+}
+
+:focus-visible {
+  outline: 2px solid var(--color-main);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    /* biome-ignore lint/complexity/noImportantStyles: global reduced-motion kill switch must beat component transitions */
+    animation-duration: 0.01ms !important;
+    /* biome-ignore lint/complexity/noImportantStyles: same as above */
+    animation-iteration-count: 1 !important;
+    /* biome-ignore lint/complexity/noImportantStyles: same as above */
+    transition-duration: 0.01ms !important;
+  }
+}
+
 a {
   color: var(--color-main);
   text-decoration: none;
 }
 
+a:hover {
+  color: var(--color-main-strong);
+}
+
 ul,
 ol {
-  padding-inline-start: 1rem;
+  padding-inline-start: 1.5rem;
 }
 
 li {
-  list-style-position: inside;
   margin: 0.25rem 0;
 }
 
@@ -37,11 +64,29 @@ li {
 .content h4,
 .content h5,
 .content h6 {
-  font-size: var(--font-size);
+  color: var(--color-title);
   font-weight: var(--font-weight-bold);
-  margin: 2rem 0 1rem;
-  line-height: 1.2;
-  letter-spacing: -0.025rem;
+  font-feature-settings: "palt";
+  margin: 2.5rem 0 1rem;
+  line-height: var(--line-height-heading);
+  letter-spacing: 0.01em;
+}
+
+.content h1,
+.content h2 {
+  font-size: var(--font-size-h2);
+  border-inline-start: 4px solid var(--color-main);
+  padding-inline-start: 0.75rem;
+}
+
+.content h3 {
+  font-size: var(--font-size-h3);
+}
+
+.content h4,
+.content h5,
+.content h6 {
+  font-size: var(--font-size);
 }
 
 .content p {
@@ -49,9 +94,20 @@ li {
   margin: 1rem 0;
 }
 
+.content a {
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, var(--color-main) 40%, transparent);
+  text-underline-offset: 0.25em;
+}
+
+.content a:hover {
+  text-decoration-color: var(--color-main-strong);
+}
+
 .content blockquote {
-  background-color: var(--color-background);
-  border-left: 5px solid var(--color-border);
+  background-color: var(--color-surface);
+  border-inline-start: 3px solid var(--color-border);
+  border-radius: 0 var(--radius-s) var(--radius-s) 0;
   color: var(--color-sub);
   padding: 0.25em 1.5em;
   margin: 1.5rem 0;
@@ -68,12 +124,41 @@ li {
 
 .content img {
   width: 100%;
+  height: auto;
+  border-radius: var(--radius-m);
   margin: 1.5rem 0;
+}
+
+.content hr {
+  border: 0;
+  border-top: 1px solid var(--color-border);
+  margin: 2.5rem 0;
+}
+
+.content table {
+  display: block;
+  width: 100%;
+  overflow-x: auto;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  font-size: var(--font-size-small);
+}
+
+.content th,
+.content td {
+  border: 1px solid var(--color-border);
+  padding: 0.5rem 0.75rem;
+  white-space: nowrap;
+}
+
+.content th {
+  background-color: var(--color-surface);
+  font-weight: var(--font-weight-bold);
 }
 
 /* Code block styles - レイアウトのみ（色は rehype-pretty-code のテーマが適用） */
 .content pre {
-  border-radius: 8px;
+  border-radius: var(--radius-m);
   padding: 1rem;
   margin: 1.5rem 0;
   overflow-x: auto;
@@ -84,9 +169,10 @@ li {
 
 /* Inline code styles */
 .content code:not(pre code) {
-  background-color: var(--color-border);
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
   padding: 0.2em 0.4em;
-  border-radius: 4px;
+  border-radius: var(--radius-s);
   font-size: var(--font-size-small);
   font-family: var(--font-family-mono);
 }
@@ -96,7 +182,7 @@ li {
   display: flex;
   align-items: stretch;
   border: 1px solid var(--color-border);
-  border-radius: 8px;
+  border-radius: var(--radius-m);
   overflow: hidden;
   margin: 1.5rem 0;
   text-decoration: none;
@@ -115,7 +201,7 @@ li {
   flex-shrink: 0;
   width: 120px;
   min-height: 100px;
-  background-color: var(--color-border);
+  background-color: var(--color-surface);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -126,6 +212,7 @@ li {
   width: 100%;
   height: 100%;
   object-fit: cover;
+  border-radius: 0;
   margin: 0;
 }
 
@@ -145,6 +232,7 @@ li {
 }
 
 .content .link-card-title {
+  color: var(--color-title);
   font-weight: var(--font-weight-bold);
   font-size: var(--font-size);
   line-height: 1.4;

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -1,14 +1,24 @@
 :root,
 [data-theme="light"] {
+  /* brand: テーマに依らずブランドピンクで塗る面 (header 等) */
+  --color-brand: #e91e63;
   --color-main: #e91e63;
+  --color-main-strong: #c2185b;
+  --color-main-soft: rgba(233, 30, 99, 0.09);
   --color-sub: #868e96;
-  --color-accent: #495057;
+  --color-accent: #343a40;
   --color-text: #495057;
+  --color-title: #212529;
   --color-background: #ffffff;
-  --color-border: #eeeeee;
-  --color-shadow: rgba(0, 0, 0, 0.1);
+  --color-surface: #f6f7f9;
+  --color-border: #e9ecef;
+  --color-shadow: rgba(33, 37, 41, 0.08);
 
   --content-width: 900px;
+  --content-width-narrow: 720px;
+
+  --radius-s: 4px;
+  --radius-m: 10px;
 
   --font-family-base:
     "Noto Sans JP", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
@@ -19,20 +29,28 @@
   --font-size-small: 0.875rem;
   --font-size: 1rem;
   --font-size-large: 1.125rem;
+  --font-size-h3: 1.125rem;
+  --font-size-h2: 1.375rem;
+  --font-size-h1: 1.75rem;
   --font-size-jumbo: 2rem;
 
   --font-weight: 400;
-  --font-weight-bold: 900;
+  --font-weight-bold: 700;
 
   --line-height: 1.8;
+  --line-height-heading: 1.4;
 }
 
 [data-theme="dark"] {
-  --color-main: #e91e63;
-  --color-sub: #868e96;
-  --color-accent: #ffffff;
-  --color-text: #ffffff;
+  --color-main: #ff6b93;
+  --color-main-strong: #ff8fae;
+  --color-main-soft: rgba(255, 107, 147, 0.14);
+  --color-sub: #9aa2ad;
+  --color-accent: #f3f4f7;
+  --color-text: #dfe2e8;
+  --color-title: #f3f4f7;
   --color-background: #282c35;
-  --color-border: #444444;
-  --color-shadow: rgba(255, 255, 255, 0.1);
+  --color-surface: #31353f;
+  --color-border: #3f4450;
+  --color-shadow: rgba(0, 0, 0, 0.4);
 }


### PR DESCRIPTION
## Summary
- The home index (5-column square tiles) clipped most Japanese titles and showed no dates, and article bodies rendered every heading at body size — both worked against the blog's main job of finding and reading posts. This reworks the index into a 3/2/1-column card grid with dates, gives article bodies a real heading hierarchy and a 720px reading measure, and softens the dark palette (off-white text, brightened pink accent).
- Pure CSS/markup changes; no content, routing, or build pipeline changes. The pink header + Permanent Marker logo identity is kept: the header now uses a theme-invariant `--color-brand` so the dark theme can lighten `--color-main` for contrast without repainting it. Google Fonts weight changes 900 → 700.

## Test plan
- [x] `pnpm test` (tsc), `pnpm lint:ci` (Biome, 0 warnings), `pnpm build` (velite + vite prerender of all 115 permalinks) all pass
- [x] Screenshot-verified home / article / profile in light + dark at 1280px and 375px via Playwright
- [ ] Verify prod deploy renders fonts (wght 700) and theme-color meta as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)