### PR TITLE
feat(design): bolder headings and square home grid

### DIFF
--- a/app/routes/__root.tsx
+++ b/app/routes/__root.tsx
@@ -54,7 +54,7 @@ export const Route = createRootRoute({
       },
       {
         rel: "stylesheet",
-        href: "https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&family=Permanent+Marker&display=swap",
+        href: "https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700;900&family=Permanent+Marker&display=swap",
       },
       {
         rel: "alternate",

--- a/components/features/article/article-info.module.css
+++ b/components/features/article/article-info.module.css
@@ -1,6 +1,6 @@
 .wrap {
   display: flex;
-  margin: 2rem 0 1rem;
+  margin: 2.5rem 0 1.5rem;
   flex-direction: column;
   justify-content: center;
   word-break: break-word;
@@ -9,7 +9,7 @@
 .headingLink {
   text-decoration: none;
   display: block;
-  margin: 0.5rem 0;
+  margin: 0 0 0.75rem;
 }
 
 .meta {

--- a/components/features/article/article-tile.module.css
+++ b/components/features/article/article-tile.module.css
@@ -11,7 +11,7 @@
     border-color 0.2s ease-out,
     box-shadow 0.2s ease-out,
     transform 0.2s ease-out;
-  height: 100%;
+  aspect-ratio: 1;
   display: flex;
   flex-direction: column;
 }
@@ -24,25 +24,27 @@
 
 .thumbnail {
   width: 100%;
-  aspect-ratio: 16 / 9;
+  height: 55%;
+  flex-shrink: 0;
   object-fit: cover;
   border-bottom: 1px solid var(--color-border);
 }
 
 .content {
-  padding: 0.75rem 1rem 1rem;
+  padding: 0.5rem 0.75rem;
   flex: 1;
+  min-height: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.25rem;
 }
 
 .title {
   color: var(--color-title);
   font-size: var(--font-size);
-  font-weight: var(--font-weight-bold);
+  font-weight: var(--font-weight-black);
   font-feature-settings: "palt";
-  line-height: 1.5;
+  line-height: 1.3;
   letter-spacing: 0.01em;
   margin: 0;
   overflow: hidden;
@@ -60,12 +62,13 @@
   font-size: var(--font-size-small);
   font-weight: var(--font-weight);
   color: var(--color-sub);
-  line-height: 1.6;
+  line-height: 1.5;
   margin: 0;
   overflow: hidden;
   display: -webkit-box;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
+  flex: 1;
 }
 
 .date {

--- a/components/ui/heading.module.css
+++ b/components/ui/heading.module.css
@@ -1,7 +1,7 @@
 .heading {
   color: var(--color-title);
   font-size: var(--font-size-h1);
-  font-weight: var(--font-weight-bold);
+  font-weight: var(--font-weight-black);
   font-feature-settings: "palt";
   letter-spacing: 0.01em;
   line-height: var(--line-height-heading);

--- a/components/ui/tile-grid.module.css
+++ b/components/ui/tile-grid.module.css
@@ -4,17 +4,5 @@
   max-width: var(--content-width);
   display: grid;
   gap: 1rem;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
-@media (max-width: 767px) {
-  .grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-@media (max-width: 519px) {
-  .grid {
-    grid-template-columns: minmax(0, 1fr);
-  }
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
 }

--- a/styles/global.css
+++ b/styles/global.css
@@ -65,9 +65,9 @@ li {
 .content h5,
 .content h6 {
   color: var(--color-title);
-  font-weight: var(--font-weight-bold);
+  font-weight: var(--font-weight-black);
   font-feature-settings: "palt";
-  margin: 2.5rem 0 1rem;
+  margin: 3rem 0 1.25rem;
   line-height: var(--line-height-heading);
   letter-spacing: 0.01em;
 }

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -29,13 +29,14 @@
   --font-size-small: 0.875rem;
   --font-size: 1rem;
   --font-size-large: 1.125rem;
-  --font-size-h3: 1.125rem;
-  --font-size-h2: 1.375rem;
-  --font-size-h1: 1.75rem;
+  --font-size-h3: 1.25rem;
+  --font-size-h2: 1.625rem;
+  --font-size-h1: 2.25rem;
   --font-size-jumbo: 2rem;
 
   --font-weight: 400;
   --font-weight-bold: 700;
+  --font-weight-black: 900;
 
   --line-height: 1.8;
   --line-height-heading: 1.4;


### PR DESCRIPTION
## Summary
- Push heading weight to 900 (article title + in-body h1-h6) with larger sizes for a stronger visual hierarchy
- Revert the home grid from #729's 3-column/16:9 cards back to a square tile layout, with tile titles matching the article page's bolder treatment

## Context

#729 (merged earlier today) deliberately moved away from square tiles and 900-weight text: square tiles clipped Japanese titles after two lines, and 900 "clogs at text sizes" per that PR's own notes. This PR knowingly overrides both of those calls per explicit request — square grid and heavier weight are the intended look going forward, accepting the title-wrapping tradeoff #729 called out.

## Test plan
- [x] `pnpm test` (tsc) passes
- [x] `pnpm lint:ci` (biome) passes with no new findings
- [x] Verified in dev server at desktop (1280px, 5 columns) and mobile (375px, 2 columns) widths that tiles render as squares
- [x] Verified article detail page heading/title rendering at desktop and mobile widths