### PR TITLE
デザイン刷新: Editorial Bold（没入型カラー＋白パネル）

### DIFF
--- a/app/routes/__root.tsx
+++ b/app/routes/__root.tsx
@@ -26,7 +26,7 @@ export const Route = createRootRoute({
       { property: "og:type", content: "website" },
       { property: "og:url", content: SITE_URL },
       { name: "twitter:card", content: "summary_large_image" },
-      { name: "theme-color", content: "#e91e63" },
+      { name: "theme-color", content: "#ea2552" },
     ],
     links: [
       {
@@ -54,7 +54,7 @@ export const Route = createRootRoute({
       },
       {
         rel: "stylesheet",
-        href: "https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700;900&family=Permanent+Marker&display=swap",
+        href: "https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,500;0,600;0,700;1,500;1,600&family=Noto+Serif+JP:wght@400;600;700&family=Roboto+Mono:wght@400;500&display=swap",
       },
       {
         rel: "alternate",

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -30,7 +30,7 @@ function HomePage() {
             title={post.title}
             created_at={post.created_at}
             excerpt={post.excerpt}
-            thumbnail={post.thumbnail}
+            category={post.category}
           />
         ))}
       </TileGrid>

--- a/components/features/article/article-info.module.css
+++ b/components/features/article/article-info.module.css
@@ -1,21 +1,34 @@
 .wrap {
   display: flex;
-  margin: 2.5rem 0 1.5rem;
   flex-direction: column;
-  justify-content: center;
+  margin: 1.5rem 0 0;
   word-break: break-word;
+}
+
+.kicker {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-small);
+  letter-spacing: 0.1em;
+  color: var(--color-brand-strong);
+}
+
+.cat {
+  text-transform: uppercase;
 }
 
 .headingLink {
   text-decoration: none;
   display: block;
-  margin: 0 0 0.75rem;
+  margin: 0.6rem 0 0;
 }
 
-.meta {
-  margin: 0.5rem 0;
+.tags {
   display: flex;
-  align-items: center;
   flex-wrap: wrap;
   gap: 0.5rem;
+  margin-top: 1.5rem;
 }

--- a/components/features/article/article-info.tsx
+++ b/components/features/article/article-info.tsx
@@ -21,14 +21,22 @@ const ArticleInfo: React.FC<Props> = ({
   tags,
 }) => (
   <div className={styles.wrap}>
+    <div className={styles.kicker}>
+      <Time created_at={created_at} />
+      {categories?.map((c) => (
+        <span key={c} className={styles.cat}>
+          {c}
+        </span>
+      ))}
+    </div>
     <Link className={styles.headingLink} href={path}>
       <Heading>{title}</Heading>
     </Link>
-    <div className={styles.meta}>
-      <Time created_at={created_at} />
-      <Badges items={categories} primary />
-      <Badges items={tags} />
-    </div>
+    {tags && tags.length > 0 && (
+      <div className={styles.tags}>
+        <Badges items={tags} />
+      </div>
+    )}
   </div>
 )
 

--- a/components/features/article/article-tile.module.css
+++ b/components/features/article/article-tile.module.css
@@ -1,76 +1,68 @@
-.tileLink {
+.row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: clamp(1rem, 3vw, 2rem);
+  align-items: baseline;
+  padding: 1.5rem 0;
+  border-top: 1px solid var(--color-page-line);
   text-decoration: none;
 }
 
-.container {
-  background: var(--color-background);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-m);
-  overflow: hidden;
-  transition:
-    border-color 0.2s ease-out,
-    box-shadow 0.2s ease-out,
-    transform 0.2s ease-out;
-  aspect-ratio: 1;
-  display: flex;
-  flex-direction: column;
-}
-
-.container:hover {
-  border-color: var(--color-main);
-  box-shadow: 0 4px 12px var(--color-shadow);
-  transform: translateY(-2px);
-}
-
-.thumbnail {
-  width: 100%;
-  height: 55%;
-  flex-shrink: 0;
-  object-fit: cover;
-  border-bottom: 1px solid var(--color-border);
-}
-
-.content {
-  padding: 0.5rem 0.75rem;
-  flex: 1;
-  min-height: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
-
 .title {
-  color: var(--color-title);
-  font-size: var(--font-size);
-  font-weight: var(--font-weight-black);
-  font-feature-settings: "palt";
-  line-height: 1.3;
-  letter-spacing: 0.01em;
-  margin: 0;
-  overflow: hidden;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  transition: color 0.2s ease-out;
+  display: inline-block;
+  font-family: var(--font-family-display);
+  font-weight: var(--font-weight-bold);
+  font-size: clamp(1.5rem, 3.6vw, 2.5rem);
+  line-height: 1.08;
+  letter-spacing: -0.01em;
+  color: var(--color-on-page);
+  text-wrap: balance;
+  transition: opacity 0.15s ease-out;
 }
 
-.tileLink:hover .title {
-  color: var(--color-main);
+.row:hover .title {
+  text-decoration: underline;
+  text-underline-offset: 6px;
+  text-decoration-thickness: 1px;
 }
 
 .excerpt {
+  font-family: var(--font-family-base);
   font-size: var(--font-size-small);
-  font-weight: var(--font-weight);
-  color: var(--color-sub);
-  line-height: 1.5;
-  margin: 0;
-  overflow: hidden;
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-  flex: 1;
+  color: var(--color-on-page-dim);
+  line-height: 1.6;
+  margin: 0.5rem 0 0;
+  max-width: 52ch;
 }
 
-.date {
-  margin-top: auto;
+.meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.25rem;
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-small);
+  letter-spacing: 0.08em;
+  color: var(--color-on-page-dim);
+  text-align: right;
+  white-space: nowrap;
+  padding-top: 0.4rem;
+}
+
+.cat {
+  text-transform: uppercase;
+}
+
+@media (max-width: 620px) {
+  .row {
+    grid-template-columns: 1fr;
+  }
+
+  .meta {
+    flex-direction: row;
+    align-items: baseline;
+    gap: 0.75rem;
+    text-align: left;
+    padding-top: 0.5rem;
+  }
 }

--- a/components/features/article/article-tile.tsx
+++ b/components/features/article/article-tile.tsx
@@ -8,7 +8,7 @@ interface Props {
   title: string
   created_at?: string
   excerpt?: string
-  thumbnail?: string
+  category?: string
 }
 
 const ArticleTile: React.FC<Props> = ({
@@ -16,28 +16,17 @@ const ArticleTile: React.FC<Props> = ({
   title,
   created_at,
   excerpt,
-  thumbnail,
+  category,
 }) => (
-  <Link href={path} className={styles.tileLink}>
-    <article className={styles.container}>
-      {thumbnail && (
-        <img
-          className={styles.thumbnail}
-          src={thumbnail}
-          alt=""
-          loading="lazy"
-        />
-      )}
-      <div className={styles.content}>
-        <h2 className={styles.title}>{title}</h2>
-        {!thumbnail && excerpt && <p className={styles.excerpt}>{excerpt}</p>}
-        {created_at && (
-          <div className={styles.date}>
-            <Time created_at={created_at} />
-          </div>
-        )}
-      </div>
-    </article>
+  <Link href={path} className={styles.row}>
+    <div className={styles.main}>
+      <span className={styles.title}>{title}</span>
+      {excerpt && <p className={styles.excerpt}>{excerpt}</p>}
+    </div>
+    <div className={styles.meta}>
+      {category && <span className={styles.cat}>{category}</span>}
+      {created_at && <Time created_at={created_at} />}
+    </div>
   </Link>
 )
 

--- a/components/features/article/article.module.css
+++ b/components/features/article/article.module.css
@@ -1,0 +1,28 @@
+.cardwrap {
+  padding: clamp(1rem, 4vw, 3rem) clamp(1rem, 4vw, 2.5rem)
+    clamp(2rem, 5vw, 3.5rem);
+}
+
+.card {
+  max-width: var(--content-width-narrow);
+  margin: 0 auto;
+  background: var(--color-panel);
+  color: var(--color-ink);
+  padding: clamp(1.75rem, 5vw, 3.75rem);
+}
+
+.back {
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-small);
+  letter-spacing: 0.1em;
+  color: var(--color-muted);
+  text-decoration: none;
+}
+
+.back:hover {
+  color: var(--color-main-strong);
+}
+
+.share {
+  margin-top: 2.5rem;
+}

--- a/components/features/article/article.module.css
+++ b/components/features/article/article.module.css
@@ -1,14 +1,14 @@
 .cardwrap {
-  padding: clamp(1rem, 4vw, 3rem) clamp(1rem, 4vw, 2.5rem)
+  max-width: var(--content-width);
+  margin: 0 auto;
+  padding: clamp(1.5rem, 4vw, 3rem) clamp(1.25rem, 5vw, 3rem)
     clamp(2rem, 5vw, 3.5rem);
 }
 
 .card {
-  max-width: var(--content-width-narrow);
-  margin: 0 auto;
   background: var(--color-panel);
   color: var(--color-ink);
-  padding: clamp(1.75rem, 5vw, 3.75rem);
+  padding: clamp(1.75rem, 5vw, 3rem);
 }
 
 .back {

--- a/components/features/article/article.tsx
+++ b/components/features/article/article.tsx
@@ -1,7 +1,8 @@
 import type React from "react"
 import ArticleInfo from "@/components/features/article/article-info"
 import Share from "@/components/icons/icon-share"
-import Container from "@/components/ui/container"
+import Link from "@/lib/router-link"
+import styles from "./article.module.css"
 
 export interface SiteMetaType {
   title: string
@@ -31,22 +32,29 @@ const Article: React.FC<Props> = ({
   site,
 }: Props) => {
   return (
-    <Container narrow>
-      <ArticleInfo
-        path={path}
-        title={title}
-        created_at={created_at}
-        categories={categories}
-        tags={tags}
-      />
-      <div
-        className="content"
-        dangerouslySetInnerHTML={{
-          __html: html,
-        }}
-      />
-      <Share url={`${site.siteUrl}${path}`} title={title || ""} />
-    </Container>
+    <div className={styles.cardwrap}>
+      <article className={styles.card}>
+        <Link href="/" className={styles.back}>
+          ← WRITING
+        </Link>
+        <ArticleInfo
+          path={path}
+          title={title}
+          created_at={created_at}
+          categories={categories}
+          tags={tags}
+        />
+        <div
+          className="content"
+          dangerouslySetInnerHTML={{
+            __html: html,
+          }}
+        />
+        <div className={styles.share}>
+          <Share url={`${site.siteUrl}${path}`} title={title || ""} />
+        </div>
+      </article>
+    </div>
   )
 }
 

--- a/components/features/profile/profile-link.module.css
+++ b/components/features/profile/profile-link.module.css
@@ -1,0 +1,23 @@
+.links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin-top: 0.5rem;
+}
+
+.btn {
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-small);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  background: #ffffff;
+  color: #16130f;
+  padding: 0.75rem 1.1rem;
+  border-radius: 0;
+  text-decoration: none;
+  transition: transform 0.15s ease-out;
+}
+
+.btn:hover {
+  transform: translateY(-2px);
+}

--- a/components/features/profile/profile-link.module.css
+++ b/components/features/profile/profile-link.module.css
@@ -5,7 +5,8 @@
   margin-top: 0.5rem;
 }
 
-.btn {
+/* .section a より詳細度を上げて、白地に濃色・下線なしを確実に効かせる */
+.links .btn {
   font-family: var(--font-family-mono);
   font-size: var(--font-size-small);
   letter-spacing: 0.1em;
@@ -18,6 +19,8 @@
   transition: transform 0.15s ease-out;
 }
 
-.btn:hover {
+.links .btn:hover {
+  color: #16130f;
+  text-decoration: none;
   transform: translateY(-2px);
 }

--- a/components/features/profile/profile-link.tsx
+++ b/components/features/profile/profile-link.tsx
@@ -1,38 +1,30 @@
 import type React from "react"
 import Container from "../../ui/container"
 import Display from "../../ui/display"
-import Flex from "../../ui/flex"
 import Section from "../../ui/section"
+import styles from "./profile-link.module.css"
+
+const LINKS: { text: string; href: string }[] = [
+  { text: "Github", href: "https://github.com/jaxx2104" },
+  { text: "Twitter", href: "https://twitter.com/jaxx2104" },
+  { text: "npm", href: "https://www.npmjs.com/~jaxx2104" },
+  { text: "SpeakerDeck", href: "https://speakerdeck.com/jaxx2104" },
+  { text: "Qiita", href: "https://qiita.com/jaxx2104" },
+  { text: "Note", href: "https://note.com/jaxx2104" },
+  { text: "Connpass", href: "https://connpass.com/user/jaxx2104/" },
+]
 
 const ProfileLink: React.FC = () => (
   <Section>
     <Container>
       <Display>Links</Display>
-      <Flex>
-        <div>
-          <li>
-            <a href="https://github.com/jaxx2104">Github</a>
-          </li>
-          <li>
-            <a href="https://twitter.com/jaxx2104">Twitter</a>
-          </li>
-          <li>
-            <a href="https://www.npmjs.com/~jaxx2104">npm</a>
-          </li>
-          <li>
-            <a href="https://speakerdeck.com/jaxx2104">SpeakerDeck</a>
-          </li>
-          <li>
-            <a href="https://qiita.com/jaxx2104">Qiita</a>
-          </li>
-          <li>
-            <a href="https://note.com/jaxx2104">Note</a>
-          </li>
-          <li>
-            <a href="https://www.npmjs.com/~jaxx2104">Connpass</a>
-          </li>
-        </div>
-      </Flex>
+      <div className={styles.links}>
+        {LINKS.map((link) => (
+          <a key={link.text} className={styles.btn} href={link.href}>
+            {link.text}
+          </a>
+        ))}
+      </div>
     </Container>
   </Section>
 )

--- a/components/features/profile/profile-others.module.css
+++ b/components/features/profile/profile-others.module.css
@@ -1,0 +1,9 @@
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0.5rem 0 0;
+}
+
+.list li {
+  margin: 0.3rem 0;
+}

--- a/components/features/profile/profile-others.tsx
+++ b/components/features/profile/profile-others.tsx
@@ -1,19 +1,22 @@
 import Container from "../../ui/container"
 import Display from "../../ui/display"
 import Section from "../../ui/section"
+import styles from "./profile-others.module.css"
 
 const ProfileOthers = () => {
   return (
     <Section>
       <Container>
         <Display>Others</Display>
-        <li>
-          リポジトリは<a href="https://github.com/jaxx2104/">こちら</a>
-        </li>
-        <li>
-          過去のデザイン制作は
-          <a href="https://old.jaxx2104.info/">こちら</a>
-        </li>
+        <ul className={styles.list}>
+          <li>
+            リポジトリは<a href="https://github.com/jaxx2104/">こちら</a>
+          </li>
+          <li>
+            過去のデザイン制作は
+            <a href="https://old.jaxx2104.info/">こちら</a>
+          </li>
+        </ul>
       </Container>
     </Section>
   )

--- a/components/features/profile/profile-user.module.css
+++ b/components/features/profile/profile-user.module.css
@@ -1,3 +1,13 @@
 .user {
   margin: 3rem auto 2rem;
 }
+
+.career {
+  list-style: none;
+  padding: 0;
+  margin: 0.75rem 0 0;
+}
+
+.career li {
+  margin: 0.3rem 0;
+}

--- a/components/features/profile/profile-user.tsx
+++ b/components/features/profile/profile-user.tsx
@@ -20,9 +20,11 @@ const ProfileUser: React.FC<Props> = ({
           <Display>Futoshi Iwashita</Display>
           <strong>jaxx2104</strong>
           <p>I&apos;m a front-end engineer in Japan 🗼</p>
-          <li>2013 ~ 2017: J-CAST</li>
-          <li>2017 ~ 2020: Recruit</li>
-          <li>2020 ~ : freee</li>
+          <ul className={styles.career}>
+            <li>2013 ~ 2017: J-CAST</li>
+            <li>2017 ~ 2020: Recruit</li>
+            <li>2020 ~ : freee</li>
+          </ul>
         </div>
         <div className={styles.user}>
           <Thumbnail src={profileImage} title="jaxx2104" size={160} circle />

--- a/components/layout/footer.module.css
+++ b/components/layout/footer.module.css
@@ -1,6 +1,28 @@
 .footer {
-  padding: 2rem 0 3rem;
-  text-align: center;
-  color: var(--color-sub);
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-top: 2rem;
+  padding: 2.4rem 0 3.4rem;
+  border-top: 1px solid var(--color-page-line);
+}
+
+.word {
+  font-family: var(--font-family-display);
+  font-size: 1.35rem;
+  color: var(--color-on-page);
+  transition: opacity 0.15s ease-out;
+}
+
+.word:hover {
+  opacity: 0.78;
+}
+
+.meta {
+  font-family: var(--font-family-mono);
   font-size: var(--font-size-small);
+  letter-spacing: 0.12em;
+  color: var(--color-on-page-dim);
 }

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -1,19 +1,17 @@
 import type React from "react"
 import Container from "@/components/ui/container"
-import Hr from "@/components/ui/hr"
 import Link from "@/lib/router-link"
 import styles from "./footer.module.css"
 
 const Footer: React.FC = () => (
   <Container>
     <div className={styles.footer}>
-      <Hr />
-      <p>コーラとバグが好き</p>
-      <Link href="/profile">
-        <p>
-          <strong>jaxx2104</strong> on Profile
-        </p>
+      <Link href="/">
+        <span className={styles.word}>jaxx2104.info</span>
       </Link>
+      <span className={styles.meta}>
+        PROGRAMS &amp; BUGS · TOKYO · SINCE 2013
+      </span>
     </div>
   </Container>
 )

--- a/components/layout/navi-logo.module.css
+++ b/components/layout/navi-logo.module.css
@@ -1,14 +1,13 @@
 .logo {
-  color: white;
-  font-family: "Permanent Marker", cursive;
-  font-size: var(--font-size-large);
-  font-weight: 900;
-  letter-spacing: -0.05rem;
-  text-transform: uppercase;
-  margin-right: 1rem;
-  transition: color 0.2s ease-out;
+  color: var(--color-on-page);
+  font-family: var(--font-family-display);
+  font-size: clamp(1.4rem, 3.5vw, 1.75rem);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: 0.01em;
+  margin: 0;
+  transition: opacity 0.15s ease-out;
 }
 
 .logo:hover {
-  color: rgba(255, 255, 255, 0.75);
+  opacity: 0.78;
 }

--- a/components/layout/navi-menu.module.css
+++ b/components/layout/navi-menu.module.css
@@ -2,16 +2,21 @@
   display: flex;
   flex-direction: row;
   align-items: center;
+  gap: 1.25rem;
 }
 
 .item {
-  color: white;
+  color: var(--color-on-page);
+  opacity: 0.8;
   cursor: pointer;
-  margin-right: 1rem;
-  font-size: var(--font-size);
-  transition: color 0.2s ease-out;
+  margin: 0;
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-small);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  transition: opacity 0.15s ease-out;
 }
 
 .item:hover {
-  color: rgba(255, 255, 255, 0.75);
+  opacity: 1;
 }

--- a/components/layout/navi.module.css
+++ b/components/layout/navi.module.css
@@ -1,10 +1,13 @@
 .header {
-  background-color: var(--color-brand);
-  position: sticky;
-  margin-bottom: 2rem;
-  top: 0;
-  z-index: 1;
-  box-shadow: 0 1px 4px var(--color-shadow);
+  padding: 1.6rem 0 1.1rem;
+}
+
+.inner {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
 }
 
 .header a {

--- a/components/layout/navi.tsx
+++ b/components/layout/navi.tsx
@@ -2,7 +2,6 @@ import type React from "react"
 import NaviLogo from "@/components/layout/navi-logo"
 import NaviMenu from "@/components/layout/navi-menu"
 import Container from "@/components/ui/container"
-import Flex from "@/components/ui/flex"
 import { useTheme } from "@/lib/ThemeContext"
 import styles from "./navi.module.css"
 
@@ -11,8 +10,8 @@ const Navi: React.FC = () => {
   return (
     <header className={styles.header}>
       <Container>
-        <Flex>
-          <NaviLogo title="jaxx2104.info" />
+        <div className={styles.inner}>
+          <NaviLogo title="jaxx2104" />
           <NaviMenu
             items={[
               { text: "Home", to: "/" },
@@ -20,7 +19,7 @@ const Navi: React.FC = () => {
               { text: theme === "light" ? "🌅" : "🌃", action: toggleTheme },
             ]}
           />
-        </Flex>
+        </div>
       </Container>
     </header>
   )

--- a/components/ui/badge.module.css
+++ b/components/ui/badge.module.css
@@ -1,24 +1,26 @@
 .badge {
-  background-color: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: 999px;
+  background-color: transparent;
+  border: 1px solid var(--color-line);
+  border-radius: 0;
   box-sizing: border-box;
-  color: var(--color-sub);
+  color: var(--color-muted);
   display: inline-block;
+  font-family: var(--font-family-mono);
   font-size: var(--font-size-small);
+  letter-spacing: 0.08em;
   line-height: 1;
   font-weight: var(--font-weight);
   outline-style: none;
   margin: auto 0;
   text-decoration-line: none;
-  padding: 0.375em 0.875em;
+  text-transform: uppercase;
+  padding: 0.5em 0.85em;
   text-align: center;
   white-space: nowrap;
 }
 
 .badge[data-primary] {
-  background-color: var(--color-main-soft);
-  border-color: transparent;
-  color: var(--color-main);
+  border-color: var(--color-main);
+  color: var(--color-main-strong);
   font-weight: var(--font-weight-bold);
 }

--- a/components/ui/display.module.css
+++ b/components/ui/display.module.css
@@ -1,14 +1,16 @@
 .display {
-  font-size: var(--display-size, var(--font-size-jumbo));
+  font-family: var(--font-family-display);
+  font-size: var(--display-size, clamp(1.9rem, 5vw, 2.75rem));
   font-weight: var(--font-weight-bold);
-  line-height: var(--line-height-heading);
-  letter-spacing: 0.01em;
-  font-feature-settings: "palt";
-  color: var(--color-main);
+  line-height: 1.05;
+  letter-spacing: -0.015em;
+  color: var(--color-on-page);
   padding: 0;
+  margin: 0 0 0.75rem;
   text-transform: none;
 }
 
 .display[data-uppercase] {
   text-transform: uppercase;
+  letter-spacing: 0.01em;
 }

--- a/components/ui/heading.module.css
+++ b/components/ui/heading.module.css
@@ -1,14 +1,14 @@
 .heading {
-  color: var(--color-title);
-  font-size: var(--font-size-h1);
-  font-weight: var(--font-weight-black);
-  font-feature-settings: "palt";
-  letter-spacing: 0.01em;
-  line-height: var(--line-height-heading);
+  color: var(--color-ink);
+  font-family: var(--font-family-display);
+  font-size: clamp(2.2rem, 7vw, 4rem);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: -0.02em;
+  line-height: 1;
   margin: 0;
-  transition: color 0.2s ease-out;
+  transition: opacity 0.2s ease-out;
 }
 
 .heading:hover {
-  color: var(--color-main);
+  opacity: 0.82;
 }

--- a/components/ui/heading.module.css
+++ b/components/ui/heading.module.css
@@ -1,7 +1,7 @@
 .heading {
   color: var(--color-ink);
   font-family: var(--font-family-display);
-  font-size: clamp(2.2rem, 7vw, 4rem);
+  font-size: clamp(2rem, 4.5vw, 3.25rem);
   font-weight: var(--font-weight-bold);
   letter-spacing: -0.02em;
   line-height: 1;

--- a/components/ui/section.module.css
+++ b/components/ui/section.module.css
@@ -1,10 +1,10 @@
 .section {
-  padding: 2rem 0 4rem;
+  padding: clamp(2rem, 5vw, 3.5rem) 0;
   position: relative;
   margin: 0 auto;
   text-align: left;
-  color: var(--color-accent);
-  background: inherit;
+  color: var(--color-on-page);
+  background: transparent;
 }
 
 .section[data-center] {
@@ -12,12 +12,12 @@
 }
 
 .section[data-variant="primary"] {
-  color: white;
-  background: var(--color-brand);
+  color: var(--color-on-page);
+  background: transparent;
 }
 
 .section[data-variant="dark"] {
-  color: white;
+  color: #ffffff;
   background: linear-gradient(
     0deg,
     rgba(0, 0, 0, 0.75),
@@ -26,10 +26,20 @@
 }
 
 .section a {
-  color: var(--color-accent);
+  color: var(--color-on-page);
+  text-decoration: underline;
+  text-decoration-color: color-mix(
+    in srgb,
+    var(--color-on-page) 45%,
+    transparent
+  );
+  text-underline-offset: 0.2em;
 }
 
-.section[data-variant="primary"] a,
+.section a:hover {
+  text-decoration-color: var(--color-on-page);
+}
+
 .section[data-variant="dark"] a {
-  color: white;
+  color: #ffffff;
 }

--- a/components/ui/tile-grid.module.css
+++ b/components/ui/tile-grid.module.css
@@ -1,8 +1,21 @@
-.grid {
-  margin: 0 auto;
-  padding: 0 1rem;
+.wrap {
   max-width: var(--content-width);
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  margin: 0 auto;
+  padding: clamp(1.5rem, 4vw, 3rem) clamp(1.25rem, 5vw, 3rem)
+    clamp(2rem, 5vw, 3.5rem);
+}
+
+.eyebrow {
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-small);
+  letter-spacing: 0.14em;
+  color: var(--color-on-page-dim);
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--color-page-line);
+}
+
+.list {
+  display: block;
 }

--- a/components/ui/tile-grid.tsx
+++ b/components/ui/tile-grid.tsx
@@ -2,7 +2,13 @@ import type React from "react"
 import styles from "./tile-grid.module.css"
 
 const TileGrid: React.FC<{ children?: React.ReactNode }> = ({ children }) => (
-  <div className={styles.grid}>{children}</div>
+  <section className={styles.wrap}>
+    <div className={styles.eyebrow}>
+      <span>LATEST WRITING</span>
+      <span>INDEX</span>
+    </div>
+    <div className={styles.list}>{children}</div>
+  </section>
 )
 
 export default TileGrid

--- a/components/ui/time.module.css
+++ b/components/ui/time.module.css
@@ -1,8 +1,9 @@
 .time {
-  color: var(--color-sub);
+  color: inherit;
   display: inline-block;
+  font-family: var(--font-family-mono);
   font-size: var(--font-size-small);
-  font-weight: var(--font-weight);
-  text-align: center;
+  letter-spacing: 0.04em;
+  font-variant-numeric: tabular-nums;
   vertical-align: baseline;
 }

--- a/styles/global.css
+++ b/styles/global.css
@@ -161,6 +161,22 @@ li {
 }
 
 /* Code block — レイアウトのみ（色は rehype-pretty-code のテーマ） */
+/* rehype-pretty-code は <figure> で囲む。figure 既定の左右マージン(40px)を
+   消して、コードブロックを本文と同じ横幅に揃える */
+.content figure[data-rehype-pretty-code-figure] {
+  margin: 1.8rem 0;
+}
+
+.content [data-rehype-pretty-code-title] {
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-small);
+  letter-spacing: 0.02em;
+  color: var(--color-muted);
+  border: 1px solid var(--color-line);
+  border-bottom: 0;
+  padding: 0.5rem 0.9rem;
+}
+
 .content pre {
   border-radius: 0;
   padding: 1.1rem 1.2rem;
@@ -169,6 +185,11 @@ li {
   font-size: var(--font-size-small);
   line-height: 1.6;
   font-family: var(--font-family-mono);
+}
+
+/* figure 内の pre は figure 側でマージンを持つので二重を避ける */
+.content figure[data-rehype-pretty-code-figure] pre {
+  margin: 0;
 }
 
 /* Inline code */

--- a/styles/global.css
+++ b/styles/global.css
@@ -1,7 +1,7 @@
 body {
   -webkit-font-smoothing: antialiased;
-  background-color: var(--color-background);
-  color: var(--color-text);
+  background-color: var(--color-page);
+  color: var(--color-on-page);
   font-family: var(--font-family-base);
   font-weight: var(--font-weight);
   font-size: var(--font-size);
@@ -17,7 +17,7 @@ body {
 }
 
 :focus-visible {
-  outline: 2px solid var(--color-main);
+  outline: 2px solid currentColor;
   outline-offset: 2px;
   border-radius: 2px;
 }
@@ -36,12 +36,8 @@ body {
 }
 
 a {
-  color: var(--color-main);
+  color: inherit;
   text-decoration: none;
-}
-
-a:hover {
-  color: var(--color-main-strong);
 }
 
 ul,
@@ -53,9 +49,14 @@ li {
   margin: 0.25rem 0;
 }
 
+/* ============================================================
+   記事本文 .content — 白いパネルの中に置かれる前提で組む
+   （Velite 生成 HTML を dangerouslySetInnerHTML で注入）
+   ============================================================ */
 .content {
   margin: 0;
   padding: 0;
+  color: var(--color-ink);
 }
 
 .content h1,
@@ -64,19 +65,17 @@ li {
 .content h4,
 .content h5,
 .content h6 {
-  color: var(--color-title);
-  font-weight: var(--font-weight-black);
-  font-feature-settings: "palt";
-  margin: 3rem 0 1.25rem;
-  line-height: var(--line-height-heading);
-  letter-spacing: 0.01em;
+  color: var(--color-ink);
+  font-family: var(--font-family-display);
+  font-weight: var(--font-weight-bold);
+  margin: 2.4rem 0 1rem;
+  line-height: 1.18;
+  letter-spacing: -0.01em;
 }
 
 .content h1,
 .content h2 {
   font-size: var(--font-size-h2);
-  border-inline-start: 4px solid var(--color-main);
-  padding-inline-start: 0.75rem;
 }
 
 .content h3 {
@@ -91,13 +90,14 @@ li {
 
 .content p {
   font-weight: var(--font-weight);
-  margin: 1rem 0;
+  margin: 1.1rem 0;
 }
 
 .content a {
+  color: var(--color-main-strong);
   text-decoration: underline;
-  text-decoration-color: color-mix(in srgb, var(--color-main) 40%, transparent);
-  text-underline-offset: 0.25em;
+  text-decoration-color: color-mix(in srgb, var(--color-main) 45%, transparent);
+  text-underline-offset: 0.22em;
 }
 
 .content a:hover {
@@ -105,16 +105,18 @@ li {
 }
 
 .content blockquote {
-  background-color: var(--color-surface);
-  border-inline-start: 3px solid var(--color-border);
-  border-radius: 0 var(--radius-s) var(--radius-s) 0;
-  color: var(--color-sub);
-  padding: 0.25em 1.5em;
-  margin: 1.5rem 0;
+  border-inline-start: 2px solid var(--color-main);
+  color: var(--color-ink);
+  font-family: var(--font-family-display);
+  font-style: italic;
+  font-size: var(--font-size-large);
+  line-height: 1.4;
+  padding: 0.1em 0 0.1em 1.4em;
+  margin: 1.8rem 0;
 }
 
 .content blockquote p {
-  margin: 1rem 0;
+  margin: 0.6rem 0;
 }
 
 .content blockquote a {
@@ -125,13 +127,13 @@ li {
 .content img {
   width: 100%;
   height: auto;
-  border-radius: var(--radius-m);
-  margin: 1.5rem 0;
+  border-radius: 0;
+  margin: 1.8rem 0;
 }
 
 .content hr {
   border: 0;
-  border-top: 1px solid var(--color-border);
+  border-top: 1px solid var(--color-line);
   margin: 2.5rem 0;
 }
 
@@ -146,55 +148,56 @@ li {
 
 .content th,
 .content td {
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--color-line);
   padding: 0.5rem 0.75rem;
   white-space: nowrap;
 }
 
 .content th {
   background-color: var(--color-surface);
+  font-family: var(--font-family-mono);
   font-weight: var(--font-weight-bold);
+  letter-spacing: 0.02em;
 }
 
-/* Code block styles - レイアウトのみ（色は rehype-pretty-code のテーマが適用） */
+/* Code block — レイアウトのみ（色は rehype-pretty-code のテーマ） */
 .content pre {
-  border-radius: var(--radius-m);
-  padding: 1rem;
-  margin: 1.5rem 0;
+  border-radius: 0;
+  padding: 1.1rem 1.2rem;
+  margin: 1.8rem 0;
   overflow-x: auto;
   font-size: var(--font-size-small);
   line-height: 1.6;
   font-family: var(--font-family-mono);
 }
 
-/* Inline code styles */
+/* Inline code */
 .content code:not(pre code) {
-  background-color: var(--color-surface);
-  border: 1px solid var(--color-border);
-  padding: 0.2em 0.4em;
+  background-color: var(--color-main-soft);
+  color: var(--color-main-strong);
+  padding: 0.12em 0.4em;
   border-radius: var(--radius-s);
-  font-size: var(--font-size-small);
+  font-size: 0.85em;
   font-family: var(--font-family-mono);
 }
 
-/* Link card styles */
+/* Link card — 角丸なしの枠線カード */
 .content .link-card {
   display: flex;
   align-items: stretch;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-m);
+  border: 1px solid var(--color-line);
+  border-radius: 0;
   overflow: hidden;
-  margin: 1.5rem 0;
+  margin: 1.8rem 0;
   text-decoration: none;
   color: inherit;
   transition:
-    box-shadow 0.2s ease,
-    border-color 0.2s ease;
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
 }
 
 .content .link-card:hover {
   border-color: var(--color-main);
-  box-shadow: 0 2px 8px var(--color-shadow);
 }
 
 .content .link-card-image {
@@ -219,12 +222,12 @@ li {
 .content .link-card-no-image span {
   font-size: 2rem;
   font-weight: bold;
-  color: var(--color-sub);
+  color: var(--color-muted);
 }
 
 .content .link-card-content {
   flex: 1;
-  padding: 0.75rem 1rem;
+  padding: 0.85rem 1rem;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -232,10 +235,11 @@ li {
 }
 
 .content .link-card-title {
-  color: var(--color-title);
+  color: var(--color-ink);
+  font-family: var(--font-family-display);
   font-weight: var(--font-weight-bold);
   font-size: var(--font-size);
-  line-height: 1.4;
+  line-height: 1.3;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
@@ -245,7 +249,7 @@ li {
 
 .content .link-card-description {
   font-size: var(--font-size-small);
-  color: var(--color-sub);
+  color: var(--color-muted);
   line-height: 1.4;
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -255,8 +259,10 @@ li {
 }
 
 .content .link-card-site {
+  font-family: var(--font-family-mono);
   font-size: var(--font-size-small);
-  color: var(--color-sub);
+  letter-spacing: 0.04em;
+  color: var(--color-muted);
 }
 
 @media (max-width: 480px) {

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -1,57 +1,92 @@
 :root,
 [data-theme="light"] {
-  /* brand: テーマに依らずブランドピンクで塗る面 (header 等) */
-  --color-brand: #e91e63;
-  --color-main: #e91e63;
-  --color-main-strong: #c2185b;
-  --color-main-soft: rgba(233, 30, 99, 0.09);
-  --color-sub: #868e96;
-  --color-accent: #343a40;
-  --color-text: #495057;
-  --color-title: #212529;
-  --color-background: #ffffff;
-  --color-surface: #f6f7f9;
-  --color-border: #e9ecef;
-  --color-shadow: rgba(33, 37, 41, 0.08);
+  /* brand: 朱寄りピンク（テーマ非依存のアクセント / ライトではページ地） */
+  --color-brand: #ea2552;
+  --color-brand-strong: #c41d49;
+  --color-main: #ea2552;
+  --color-main-strong: #c41d49;
+  --color-main-soft: rgba(234, 37, 82, 0.1);
 
-  --content-width: 900px;
+  /* immersive page（色面）: ライトはブランド色でベタ塗り */
+  --color-page: #ea2552;
+  --color-on-page: #fff0f2;
+  --color-on-page-dim: rgba(255, 240, 242, 0.74);
+  --color-page-line: rgba(255, 240, 242, 0.26);
+
+  /* white reading panel（記事本文の白いシート） */
+  --color-panel: #ffffff;
+  --color-ink: #16130f;
+  --color-muted: #7c766e;
+  --color-line: #ece7df;
+
+  /* legacy aliases（未改修参照のフォールバック） */
+  --color-text: var(--color-ink);
+  --color-title: var(--color-ink);
+  --color-sub: var(--color-muted);
+  --color-accent: var(--color-ink);
+  --color-background: var(--color-panel);
+  --color-surface: #f4f2ee;
+  --color-border: var(--color-line);
+  --color-shadow: rgba(20, 16, 12, 0.12);
+
+  --content-width: 1000px;
   --content-width-narrow: 720px;
 
-  --radius-s: 4px;
-  --radius-m: 10px;
+  /* sharp corners が基本。inline code 等の小面のみ radius-s */
+  --radius-s: 3px;
+  --radius-m: 0px;
 
+  /* type: ハイコントラスト・セリフ見出し × 本文セリフ × モノスペース */
+  --font-family-display:
+    "Playfair Display", "Didot", "Bodoni 72", "Noto Serif JP",
+    "Hiragino Mincho ProN", "Yu Mincho", Georgia, "Times New Roman", serif;
   --font-family-base:
-    "Noto Sans JP", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-    "Helvetica Neue", Arial, sans-serif;
+    "Noto Serif JP", "Iowan Old Style", "Palatino Linotype", Palatino,
+    "Hiragino Mincho ProN", "Yu Mincho", Georgia, serif;
   --font-family-mono:
-    "Consolas", "Monaco", "Andale Mono", "Ubuntu Mono", monospace;
+    "Roboto Mono", "SF Mono", ui-monospace, Menlo, Consolas,
+    "Hiragino Kaku Gothic ProN", monospace;
 
-  --font-size-small: 0.875rem;
-  --font-size: 1rem;
-  --font-size-large: 1.125rem;
-  --font-size-h3: 1.25rem;
-  --font-size-h2: 1.625rem;
-  --font-size-h1: 2.25rem;
-  --font-size-jumbo: 2rem;
+  --font-size-small: 0.8125rem;
+  --font-size: 1.0625rem;
+  --font-size-large: 1.1875rem;
+  --font-size-h3: 1.375rem;
+  --font-size-h2: 1.75rem;
+  --font-size-h1: 2.5rem;
+  --font-size-jumbo: 2.25rem;
 
   --font-weight: 400;
-  --font-weight-bold: 700;
-  --font-weight-black: 900;
+  --font-weight-bold: 600;
+  --font-weight-black: 700;
 
-  --line-height: 1.8;
-  --line-height-heading: 1.4;
+  --line-height: 1.78;
+  --line-height-heading: 1.12;
 }
 
 [data-theme="dark"] {
-  --color-main: #ff6b93;
-  --color-main-strong: #ff8fae;
-  --color-main-soft: rgba(255, 107, 147, 0.14);
-  --color-sub: #9aa2ad;
-  --color-accent: #f3f4f7;
-  --color-text: #dfe2e8;
-  --color-title: #f3f4f7;
-  --color-background: #282c35;
-  --color-surface: #31353f;
-  --color-border: #3f4450;
-  --color-shadow: rgba(0, 0, 0, 0.4);
+  --color-brand: #fc637a;
+  --color-brand-strong: #ff8494;
+  --color-main: #fc637a;
+  --color-main-strong: #ff8494;
+  --color-main-soft: rgba(252, 99, 122, 0.14);
+
+  /* dark: 全面ベタは眩しいため、濃いニュートラル地＋ブランドアクセント */
+  --color-page: #0e0c0b;
+  --color-on-page: #f1ebe0;
+  --color-on-page-dim: rgba(241, 235, 224, 0.72);
+  --color-page-line: rgba(241, 235, 224, 0.16);
+
+  --color-panel: #17130f;
+  --color-ink: #f1ebe0;
+  --color-muted: #9a9188;
+  --color-line: #2a251f;
+
+  --color-text: var(--color-ink);
+  --color-title: var(--color-ink);
+  --color-sub: var(--color-muted);
+  --color-accent: var(--color-ink);
+  --color-background: var(--color-panel);
+  --color-surface: #221e18;
+  --color-border: var(--color-line);
+  --color-shadow: rgba(0, 0, 0, 0.5);
 }


### PR DESCRIPTION
## 概要

ブログ全体のビジュアルを **Editorial Bold** に刷新します。既存リポジトリを直接いじると制約に引きずられて凡庸になりがちだったため、**隔離モック（Artifact）でデザインを先に発散・確定してから移植**する方式を採用しました。数回の反復（3方向比較 → Editorial 系を選択 → Hermes Agent を参照に振り切り → 引き算 → 色調整）を経て意匠を確定しています。

**IA（ページ構成・情報設計・データ層）は維持し、ビジュアルのみ刷新**しています。

確定リファレンス（隔離モック）: https://claude.ai/code/artifact/a2fd144e-39cf-46e6-bcb8-d6dda4c0512c

## 主な変更

- **没入型カラー**: ページ全体を朱寄りピンク `#ea2552` でベタ塗り、記事本文だけ「ブランド色の余白に囲まれた白いパネル」として表示。ダークは眩しさを避け濃いニュートラル地＋ブランドアクセントに切替
- **タイポ**: ハイコントラスト・セリフ見出し × モノスペース大文字ラベルの対比。`app/routes/__root.tsx` に Web フォント（Playfair Display / Noto Serif JP / Roboto Mono）を追加
- **ナビ / フッター**: 左揃え・透過・非sticky。セリフのワードマーク＋モノスペースのナビ
- **ホーム**: カードグリッド → セリフ大タイトル＋モノ日付/カテゴリの書誌インデックス（ヘアライン区切り）
- **記事**: 枠付き白パネル。モノのキッカー＋巨大セリフ見出し＋角丸なしタグ
- **プロフィール**: 色面上レイアウト。Links を白の角丸なしボタン群に（Work は実スクショ維持）
- **tokens.css**: 没入型パレット＋新タイポに再定義（未改修参照向けに legacy alias は保持）、`theme-color` も `#ea2552` に更新

## 変更範囲

`styles/tokens.css`・`styles/global.css`、`app/routes/{__root,index}.tsx`、`components/` 配下のナビ/フッター/一覧/記事/プロフィール/UI プリミティブの `.module.css` と一部 JSX。ルーティング・データ層・Velite・React 構造・props 規約は不変。

## 検証

- `pnpm build`（velite build + vite prerender、113記事）✅
- `pnpm test`（tsc 型チェック）✅
- `pnpm lint:ci`（Biome）✅
- ローカルで **ホーム / 記事 / プロフィール × ライト・ダーク** をスクリーンショット確認し、確定モックと一致

### 本番差分の注意

見出しの Didone コントラストは Web フォント（Playfair Display + Noto Serif JP）で全環境対応させています。本番デプロイで細太コントラストが効きます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4zqmpcXUjC4ww32MSksNk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4zqmpcXUjC4ww32MSksNk)_