### PR TITLE
記事: Hermes 移行記を差分主軸の構成に書き直し

### DIFF
--- a/content/posts/2026-07-06-openclaw-to-hermes-agent/index.md
+++ b/content/posts/2026-07-06-openclaw-to-hermes-agent/index.md
@@ -1,9 +1,9 @@
 ---
 title: "OpenClaw から Hermes Agent へと移行した"
 created_at: '2026-07-06T00:00:00.000Z'
-updated_at: '2026-07-06T00:00:00.000Z'
+updated_at: '2026-07-11T00:00:00.000Z'
 path: /openclaw-to-hermes-agent
-description: "NUC 常駐のパーソナル AI エージェントを OpenClaw から Hermes Agent (Nous Research) に乗り換えた。公式移行コマンド claw migrate、heartbeat と cron の設計差、文字数上限付きメモリ、モデル設定の自由度など、機能面の違いを中心にまとめる。"
+description: "NUC 常駐のパーソナル AI エージェントを OpenClaw から Hermes Agent (Nous Research) に乗り換えた。いちばん効いたのは heartbeat が cron に置き換わって定期タスクが安定したこと。みんなが目玉と褒めるスキル自動生成は、気づけば勝手に育っていた。"
 category: 開発環境
 tags:
   - openclaw
@@ -12,21 +12,30 @@ tags:
   - agent
 ---
 
-自宅の NUC で常駐させているパーソナル AI エージェントを、[OpenClaw](https://github.com/openclaw/openclaw)から Nous Research の Hermes Agent に移行しました。Telegram と Slack の DM で話しかけると[Home Assistant](/home-assistant-setup-log-2026)を操作したり、定期タスクでブログのネタ出しをしてくれたりするエージェントです。きっかけはローカル LLM を primary にしたいというコスト側の事情でしたが、乗り換えてみると両者の設計の違いの方が面白かったので、この記事は機能面の差を中心にまとめます。
+自宅の NUC で常駐させているパーソナル AI エージェントを、[OpenClaw](https://github.com/openclaw/openclaw)から Nous Research の[Hermes Agent](https://hermes-agent.nousresearch.com/)に移行しました。Telegram と Slack の DM で話しかけると[Home Assistant](/home-assistant-setup-log-2026)を操作したり、定期タスクでブログのネタ出しをしてくれたりするエージェントです。移行の動機は単純です。話題になっていたので機能を比べて、試したくなった。
 
 TL;DR:
 
-- `hermes claw migrate`という公式の移行コマンドがあり、人格・記憶・モデル設定・MCP はほぼ自動で移った
-- いちばん大きい機能差は定期タスク。heartbeat のポーリングと自前の時間窓判定が、cron 式スケジューラに置き換わった
-- メモリは自由記述の Markdown から文字数上限付きの組み込みツールに変わった。上限満杯でターンが静かにハングする罠を初日に踏んだ
-- モデル設定は Hermes の方が細かく効く。ただしローカル 8B の日本語品質が壁で、primary は OpenRouter のまま
-- OpenClaw は停止のみで残してあり、2 週間の観察後に退役予定
+- 移行していちばん効いたのは定期タスクの安定。heartbeat のポーリングと時間窓判定が cron 式スケジューラに置き換わり、自前実装がごっそり消えた
+- `hermes claw migrate`という公式の移行コマンドがあり、人格・記憶・モデル設定・MCP はほぼ自動で移った。ただし罠が 2 つ
+- メモリは文字数上限付きに変わり、上限満杯でターンが静かにハングする罠を初日に踏んだ
+- みんなが目玉と褒めるスキル自動生成は、気づいたら local skill 6 個とメモリ 30 個を溜めていた
+- 出戻りはたぶん無い
 
-## 移行前の構成
+## きっかけは話題性、決め手は機能比較
 
-OpenClaw は 2026-06-14 から NUC (Intel N95/8GB) で動かしていました。systemd user service で常駐し、モデルは[OpenRouter](https://openrouter.ai/)の deepseek-v3.2、定期タスクは heartbeat で 4 本(週末のブログネタ出し・技術トレンド収集・メモリ蒸留・GitHub 活動ログ)。ワークスペースの Markdown はリポジトリで config-as-code 管理して、Claude Code で編集後に NUC へ rsync する運用です。[ESP-Claw を触ってみている](/esp-claw/)の記事で比較対象にしていたのが、この構成でした。
+Hermes Agent が話題になっていたので、OpenClaw と機能を比べてみたのが始まりです。惹かれたのは定期タスクと skill まわりでした。
 
-3 週間運用してみて正直コストがきつく、heartbeat の間隔を 30 分から 60 分に伸ばし、モデルを 2 回替え、朝のダイジェスト配信を廃止しています。ローカル LLM を主戦力にできれば話が早いのですが、OpenClaw のモデル設定は 1 本の文字列で、プロバイダの使い分けを細かく制御できません。そこで provider まわりの自由度が高い[Hermes Agent](https://hermes-agent.nousresearch.com/)を試すことにしました。
+| 軸 | OpenClaw | Hermes Agent |
+| --- | --- | --- |
+| 定期タスク | heartbeat(ポーリング + 自前の時間窓判定) | cron 式スケジューラ |
+| メモリ | 自由記述の Markdown | 文字数上限付き組み込みツール + 外部プロバイダ |
+| モデル設定 | 1 本の文字列 | provider 分離・custom endpoint |
+| skill 配布 | なし(ワークスペースに自前で書く) | official カタログ約 100 個 + スキル自動生成 |
+
+両者の設計思想の比較は[laiso さんの記事](https://blog.lai.so/hermes-agent/)が詳しいです。この記事は移行して自分の運用がどう変わったかの備忘録です。
+
+移行前は NUC (Intel N95/8GB) の systemd user service で OpenClaw を常駐させていました。モデルは[OpenRouter](https://openrouter.ai/)の deepseek-v3.2、定期タスクは heartbeat で 4 本(週末のブログネタ出し・技術トレンド収集・メモリ蒸留・GitHub 活動ログ)です。ワークスペースの Markdown はリポジトリで config-as-code 管理して、[Claude Code](https://claude.com/claude-code)で編集後に NUC へ rsync する運用です。[ESP-Claw を触ってみている](/esp-claw/)の記事で比較対象にしていたのが、この構成でした。
 
 ## hermes claw migrate で引っ越す
 
@@ -37,13 +46,11 @@ hermes skills install official/migration/openclaw-migration --yes
 hermes claw migrate
 ```
 
-これで人格 (SOUL.md)・ユーザープロフィール (USER.md)・長期記憶 (MEMORY.md)・日次メモリ・モデル設定・MCP サーバー定義が一括で移ります。嬉しい誤算だったのは自動要約で、220 行あった USER.md を Hermes 側の文字数上限(約 1,375 字)に合わせて勝手に圧縮してくれました。
+これで人格 (SOUL.md)・ユーザープロフィール (USER.md)・長期記憶 (MEMORY.md)・日次メモリ・モデル設定・MCP サーバー定義が一括で移ります。嬉しい誤算だったのは自動要約で、220 行あった USER.md を Hermes 側の文字数上限(約 1,375 字)に合わせて自動で圧縮してくれました。チャネルも Telegram bot と Slack app のトークンをそのまま流用できます。
 
-罠も 2 つ踏んでいます。1 つは secret の扱いで、migrate は OpenClaw の SecretRef を展開して Home Assistant の JWT を config.yaml に生値で焼き込みます。`~/.hermes/.env`に移して`Authorization: Bearer ${MCP_HOME_ASSISTANT_API_KEY}`の環境変数参照に書き換えました。もう 1 つはモデル指定の形式です。OpenClaw の`openrouter/deepseek/deepseek-v3.2`という 1 本の文字列がそのまま`model.default`に入り、"not a valid model ID" で 400 になります。Hermes は provider と model を分離する設計なので、手で直しました。
+罠は 2 つ踏みました。1 つは secret の扱いで、migrate は OpenClaw の SecretRef を展開して Home Assistant の JWT を config.yaml に生値で焼き込みます。`~/.hermes/.env`に移して`Authorization: Bearer ${MCP_HOME_ASSISTANT_API_KEY}`の環境変数参照に書き換えました。もう 1 つはモデル指定の形式です。OpenClaw の`openrouter/deepseek/deepseek-v3.2`という 1 本の文字列がそのまま`model.default`に入り、"not a valid model ID" で 400 になります。Hermes は provider と model を分離する設計なので、手で直しました。
 
-チャネルは Telegram bot と Slack app のトークンをそのまま流用できました。Hermes はトークンが存在するチャネルを自動で有効にする方式で、owner 限定にするには`TELEGRAM_ALLOWED_USERS`/`SLACK_ALLOWED_USERS`を置きます。
-
-## いちばんの機能差は定期タスク: heartbeat から cron へ
+## cron で自前実装がごっそり消えた
 
 OpenClaw の定期タスクは heartbeat という仕組みでした。60 分ごとに HEARTBEAT.md をエージェントに読ませ、該当タスクがなければ`HEARTBEAT_OK`を返させるポーリング型です。この方式だと「いつ実行するか」の判定をタスク側のプロンプトに書く必要があります。実際の HEARTBEAT.md はこうなっていました。
 
@@ -57,7 +64,7 @@ OpenClaw の定期タスクは heartbeat という仕組みでした。60 分ご
 今日の日付と一致していれば実行済み＝スキップ。実行したら今日の日付を書き込む。
 ```
 
-時間窓の判定も重複防止の state ファイルも、LLM に読ませるプロンプトとして自前実装するわけです。窓を 1 時間に設計しておかないと 60 分間隔の tick から漏れる、といった暗黙の結合もあります。
+時間窓の判定も重複防止の state ファイルも、LLM に読ませるプロンプトとして自前実装するわけです。窓を 1 時間に設計しておかないと 60 分間隔の tick から漏れる、といった暗黙の結合もあります。タスクがない時間も LLM が空回りするので空振りに課金され続けるのも地味に嫌で、運用中に間隔を 30 分から 60 分に伸ばしたり、朝のダイジェスト配信を廃止したりとチューニングしていました。
 
 Hermes は普通の cron でした。
 
@@ -65,15 +72,15 @@ Hermes は普通の cron でした。
 hermes cron create "0 10 * * 6" "<タスクのプロンプト>" --name weekend-draft --deliver slack:<チャネル ID>
 ```
 
-cron 式はシステムのタイムゾーン (JST) で解釈されるので、そのまま土曜 10:00 と書けます。時間窓判定と heartbeat-state.json は丸ごと消え、タスクがない時間に LLM が空回りすることもなくなりました。4 本のタスクは定義スクリプトごとリポジトリへ置き、冪等に再インストールできる形で管理しています。
+cron 式はシステムのタイムゾーン (JST) で解釈されるので、そのまま土曜 10:00 と書けます。時間窓判定と heartbeat-state.json は丸ごと消え、空回りもなくなりました。4 本のタスクは定義スクリプトごとリポジトリへ置き、冪等に再インストールできる形で管理しています。
 
-cron 側にも罠はありました。cron エージェントの terminal ツールは POSIX シェル経由でコマンドを実行するので、URL 中の`&`をクォートせずに書くとバックグラウンド実行として解釈され、本体のリクエストが捨てられて出力が空になります。GitHub 活動ログのタスクがこれを踏んで、実際にはコミットがあるのに「過去 7 日の活動なし」と誤報しました。いまはプロンプト側で`gh api -f KEY=VALUE`の`&`を含まない形式を強制しています。
+cron 側にもハマりどころはありました。cron エージェントの terminal ツールは POSIX シェル経由でコマンドを実行するので、URL 中の`&`をクォートせずに書くとバックグラウンド実行として解釈され、本体のリクエストが捨てられて出力が空になります。GitHub 活動ログのタスクがこれを踏んで、実際にはコミットがあるのに「過去 7 日の活動なし」と誤報しました。いまはプロンプト側で`gh api -f KEY=VALUE`の`&`を含まない形式を強制しています。それでも、実行タイミングの制御をプロンプトに書いていた頃より確実に安定しています。
 
-## メモリは自由記述から上限付き組み込みツールへ
+## メモリ上限で初日にハングした
 
 OpenClaw のメモリはワークスペースの Markdown をエージェントが自由に読み書きする方式で、肥大化の管理は週次の蒸留タスクという運用でカバーしていました。Hermes は`memory`ツールが組み込みで、MEMORY.md にデフォルト約 2,200 字(USER.md は約 1,375 字)の上限があります。毎ターン context に注入される前提だから上限でトークンを抑える、という設計です。
 
-この上限で初日に事故りました。Slack で URL を覚えておいてと頼んだところ、ターンが「⏳ Working — iteration 8/90」のまま 27 分固まったのです。NUC 側で見ると gateway プロセスはネットワーク待ちのまま止まっていて、SIGTERM にも応答せず SIGKILL で強制終了しました。原因は MEMORY.md が 2,169/2,200 字でほぼ満杯だったこと。`memory add`が上限で弾かれ続け、整理(consolidation)の失敗を重ねた末にターンごと止まっていました。
+初日からこの上限に引っかかりました。Slack で URL を覚えておいてと頼んだところ、ターンが`⏳ Working — iteration 8/90`のまま 27 分固まったのです。NUC 側で見ると gateway プロセスはネットワーク待ちのまま止まっていて、SIGTERM にも応答せず SIGKILL で強制終了しました。原因は MEMORY.md が 2,169/2,200 字でほぼ満杯だったこと。`memory add`が上限で弾かれ続け、整理(consolidation)の失敗を重ねた末にターンごと止まっていました。
 
 回避は設定 1 つです。
 
@@ -85,39 +92,16 @@ hermes config set memory.memory_char_limit 4400
 
 書き味なら、個人的には OpenClaw の自由記述に分があると思います。ただ、あちらは際限なく太る問題を運用で抑えていたのに対し、Hermes は上限という形で設計に織り込んでいる。不便さの種類が違うだけで、真面目に向き合っているのは Hermes の方だと感じます。
 
-## モデル設定は細かく効く、ただし実力は別問題
+## スキル自動生成は勝手に育っていた
 
-移行の動機だったモデルまわりは、期待どおり自由度が上がりました。provider と model が分離していて、custom provider で任意の OpenAI 互換エンドポイントに直結できます。Windows のゲーミング PC (RTX 5070Ti 16GB) で動かしている[Ollama](https://ollama.com/)をネットワーク越しに繋ぎました。
+Hermes のレビュー記事は、ほぼ例外なくスキル自動生成を目玉として褒めています。使うほどエージェントが自分でスキルを書いて賢くなる、というあれです。移行の決め手の半分は skill まわりだったので、この機能があることは知っていました。ただ、意図して使ってはいませんでした。
 
-```bash
-hermes config set model.provider custom
-hermes config set model.base_url http://iwawin:11434/v1
-hermes config set model.default hermes3-64k:8b
-```
+ところがこの記事を直すにあたって実機を見たら、勝手に動いていました。`hermes skills list`に、インストールした覚えのない local skill が 6 個並んでいます。はっきり出自が分かったのは、自分が Claude Code 用に書いたブログ執筆 skill の写し(タイムスタンプは移行日)。残りは cron の最適化手順や[Tailscale](https://tailscale.com/)越しのサービス構成など、移行後の運用から書き起こされたように見えます。学習タイムライン(`hermes journey`)にはメモリも 30 個積み上がっていました。
 
-Ollama の OpenAI 互換 API は num_ctx をリクエストで受けないので、`/api/create`で num_ctx 65536 を焼き込んだ派生モデルを作って対処します。8B の Q4 量子化なら 64k コンテキストでも VRAM 13.1GB で、16GB に収まりました。
+写しには勝手な追記も入っていました。「骨子の確認がないまま本文を書き始めてはいけない」という禁止文が、同じ文面のまま 2 回重ねて足されています。スキルの棚卸し役(curator)は 7 日間隔の設定でまだ 0 回、生成・改変されたスキルのレビューは人間側もこれからです。中身を読んでから、この記事に追記するか別の記事にします。
 
-主モデル以外の振り分けもあります。Hermes には auxiliary client という補助タスク用のルーターがあり、vision・要約圧縮・コマンドの自動承認・タイトル生成など 10 種類のタスクを主モデルと別のプロバイダに振れます。OpenClaw では全部が 1 本のモデル設定に乗っていたので、ここは明確に細かい。ただしデフォルトの`provider: auto`は未ログインの Nous Portal を毎ターン探しに行ってログを警告で埋めるので、全部 OpenRouter に固定しました。複数モデルの回答を束ねる MoA という仕組みもありますが、出荷時プリセットが gpt-5.5 と Opus を参照する高コスト構成だったので、うっかり発火させる前に安価な構成へ差し替えています。
+## 出戻りはたぶん無い
 
-肝心のローカル primary 化は、設定ではなくモデルの実力で崩れました。hermes3:8b (Q4) に人格と記憶を注入して日本語で自己紹介させたら、オーナーを認識せず「お三品かもしれませんが」のような非文が返ってきます。system prompt は正しく渡っていることを確認したので、これは 8B 量子化モデルの日本語の実力です。Hermes はモデルに 64K コンテキストを要求するため、16GB VRAM で載る 14B 級も選択肢から落ち、結局 primary は OpenRouter の deepseek-v3.2 のまま。ローカルの Ollama は fallback に回しました。設定の自由度が上がっても、日本語で常用できるローカルモデルがないと絵に描いた餅です。
+OpenClaw は停止したまま`~/.openclaw`ごと残してありますが、戻す理由が見当たりません。定期タスクの安定だけで移行した甲斐がありました。
 
-## そのほかの違い
-
-書き切れなかった差分を並べておきます。
-
-| 軸 | OpenClaw | Hermes Agent |
-| --- | --- | --- |
-| 定期タスク | heartbeat(ポーリング + 自前の時間窓判定) | cron 式スケジューラ |
-| メモリ | 自由記述の Markdown | 文字数上限付き組み込みツール + 外部プロバイダ |
-| モデル設定 | 1 本の文字列 | provider 分離・custom endpoint・auxiliary の別プロバイダ振り分け |
-| skill 配布 | なし(ワークスペースに自前で書く) | official カタログ約 100 個 + インストール時セキュリティスキャン |
-| Web UI | tailnet ゲートのみ(パスワード無しで公開できた) | 非 loopback では basic 認証が強制 |
-| サンドボックス | 非 main セッションを Docker で隔離 | cron も main context で実行(コマンド承認で制御) |
-
-Web UI の認証強制はひと手間増えますが、`--insecure`フラグすら no-op 化されていて、逃げ道を残さない方針が徹底しています。サンドボックスだけは逆に OpenClaw の方が手厚いです。
-
-## OpenClaw はまだ消さない
-
-OpenClaw は停止しただけで`~/.openclaw`ごと残してあります。チャネルのトークンを共有しているので、systemd のサービスを入れ替えれば数分でロールバックできる状態です。cron 4 本が 2 週連続で定時配信に成功する、fallback の実績が 1 回以上ある、といった退役条件をチェックリストにして、満たしたら片付けます。
-
-機能面だけ見れば、定期タスクの cron 化とメモリ上限の設計だけでも移行した甲斐がありました。当初の目的だったローカル LLM の primary 化は宿題として残っているので、16GB VRAM で日本語が実用になる 64k コンテキストのモデルが出てきたら、また構成を見直すつもりです。
+宿題も残っています。ローカル LLM の primary 化です。Windows のゲーミング PC で動かしている[Ollama](https://ollama.com/)を繋いでみたものの、hermes3:8b (Q4) に人格と記憶を注入して日本語で自己紹介させると「お三品かもしれませんが」のような非文が返ってきます。Hermes はモデルに 64K コンテキストを要求するため、16GB VRAM で載る 14B 級も選択肢から落ちました。primary は OpenRouter のまま(現在 deepseek-v4-flash)で、ローカルを fallback に回しています。16GB VRAM で日本語が実用になる 64k コンテキストのモデルが出てきたら、また構成を見直すつもりです。それまでの楽しみは、勝手に増えていく local skill の観察です。


### PR DESCRIPTION
## Summary

公開済みの Hermes 移行記 (#736) は機能軸で並べる比較記事のテンプレ構成で、書いた本人も「微妙」と感じていた。類例調査（日英 30 本超）で既出・空白を洗い出し、本人ヒアリングで確認した本当の動機（話題だったので機能比較して導入）を軸に構成を書き直した。

- 記事の中心を「cron による定期タスクの安定」と「スキル自動生成の実データ」に変更し、既出のトピック（migrate 手順・思想比較・対比表の大半）は圧縮またはリンク送り
- AI が創作していた「コスト事情がきっかけ」という動機を削除
- 実機（NUC）裏取りで判明した事実を反映: スキル自動生成は無効どころか稼働中で local skill 6 個・メモリ 30 個を蓄積済み、うち 1 つは自作 skill の写しに勝手な追記入り。primary モデルは deepseek-v4-flash に変更済み
- 文体レビュー（subagent 2 周）: jaxx 度 10/10・AI 臭度 9/10 で収束、textlint クリーン

## Test plan

- [x] `pnpm lint:text` がエラーなしで通る
- [x] 本文中の URL の実在確認（新規追加分は curl で 200 確認）
- [x] 実機の設定値・スキル一覧と記事の記述が一致することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EcJwXM9EYaWZ8VGg6nUfkk