### PR TITLE
fix: remove AI-sounding expressions and metaphors in hermes-opencode-go

### DIFF
--- a/content/posts/2026-07-21-hermes-opencode-go/index.md
+++ b/content/posts/2026-07-21-hermes-opencode-go/index.md
@@ -12,7 +12,7 @@ tags:
   - agent
 ---
 
-[前回移行した](/openclaw-to-hermes-agent)NUC 常駐の[Hermes Agent](https://hermes-agent.nousresearch.com/)の primary モデルを、[OpenRouter](https://openrouter.ai/)の従量課金から[OpenCode](https://opencode.ai/) Go という月 $10 の定額プランに切り替えました。きっかけはコストが痛かったからではありません。先にやりたい使い方がありました。cron の日次化や、「リンクを DM に投げておくと後で要約が返ってくる」ような、エージェントを呼ぶ回数を増やす使い方です。従量課金のままでは、呼ぶたびに財布の減る心理が邪魔でした。
+[前回移行した](/openclaw-to-hermes-agent)NUC 常駐の[Hermes Agent](https://hermes-agent.nousresearch.com/)の primary モデルを、[OpenRouter](https://openrouter.ai/)の従量課金から[OpenCode](https://opencode.ai/) Go という月 $10 の定額プランに切り替えました。きっかけはコストが高かったからではありません。先にやりたい使い方がありました。cron の日次化や、「リンクを DM に投げておくと後で要約が返ってくる」ような、エージェントを呼ぶ回数を増やす使い方です。従量課金のままでは、呼ぶたびにコストが気になっていました。
 
 TL;DR:
 
@@ -28,13 +28,13 @@ TL;DR:
 
 - モデルは単価で選ぶ。primary を[DeepSeek](https://www.deepseek.com/)の deepseek-v3.2 にしたときの理由は per-token 単価の安さで、その後の deepseek-v4-flash への切替も同じ発想でした
 - 定期タスクは週次に束ねる。技術トレンド収集は金曜 20:00、GitHub 活動ログは金曜 22:00。毎日回す発想はなく、まとめて週 1 回です
-- 空振りを嫌う。[OpenClaw](https://github.com/openclaw/openclaw)時代は heartbeat の空振り課金が嫌で間隔を 30 分から 60 分に伸ばしていました。Hermes Agent に移ってからも、複数モデルへ並行で答えさせて集約する MoA は出荷時デフォルト(gpt-5.5 と opus を参照モデルに使う)だと高いので封印しました。auxiliary(組み込みの補助タスク)が Nous のエンドポイントを無駄にプローブするのも止めています
+- 空振り課金を避ける。[OpenClaw](https://github.com/openclaw/openclaw)時代は heartbeat の空振り課金が嫌で間隔を 30 分から 60 分に伸ばしていました。Hermes Agent に移ってからも、複数モデルへ並行で答えさせて集約する MoA は出荷時デフォルト(gpt-5.5 と opus を参照モデルに使う)だと高いので封印しました。auxiliary(組み込みの補助タスク)が Nous エンドポイントを無駄にプローブするのも止めています
 
 どれも単体では合理的です。ただ全体としては「エージェントを呼ぶこと自体を節約する」方向に設計が寄っていく。冒頭に書いた、呼ぶ回数を増やしたい構想とは真逆です。
 
 ## transport だけ替える
 
-[OpenCode Go](https://opencode.ai/go)は、コーディングエージェント OpenCode の定額プランです(初月 $5、以降月 $10)。[Z.ai](https://z.ai/)の glm-5.2 や[Moonshot AI](https://www.moonshot.ai/)の kimi-k2.7-code、deepseek-v4-pro といったオープン系モデルが対象で、レート制限はドル建て(5 時間 $12・週 $30・月 $60)。同じ枠でも単価の安いモデルほどたくさん呼べる仕組みです。公式が「any agent で使える」と謳っているとおり OpenAI 互換のエンドポイントが生えていて、Hermes Agent からは custom provider として繋がります。現在の設定はこうなっています。
+[OpenCode Go](https://opencode.ai/go)は、コーディングエージェント OpenCode の定額プランです(初月 $5、以降月 $10)。[Z.ai](https://z.ai/)の glm-5.2 や[Moonshot AI](https://www.moonshot.ai/)の kimi-k2.7-code、deepseek-v4-pro といったオープン系モデルが対象で、レート制限はドル建て(5 時間 $12・週 $30・月 $60)。同じ枠でも単価の安いモデルほどたくさん呼べる仕組みです。公式が「any agent で使える」と書いている通り OpenAI 互換のエンドポイントが生えていて、Hermes Agent からは custom provider として繋がります。現在の設定はこうなっています。
 
 ```yaml
 model:
@@ -60,7 +60,7 @@ fallback_providers:
 
 定額に移って、モデルの選び方が変わりました。従量では単価表とにらめっこでしたが、枠内ならどのモデルを選んでも請求は $10 のまま。基準が単価から速度とレート枠に入れ替わりました。
 
-比較したのは、どちらも Go 枠内の glm-5.2 と kimi-k3 です。glm-5.2 を選んだ理由は 3 つあります。
+比較したのは、どちらも Go 枠内の glm-5.2 と kimi-k3 です。glm-5.2 にしたのは、
 
 - 生成が 3 倍ほど速い。DM の応答性に効く
 - レート枠が広い。夜の cron のように、ツールを何十回も呼ぶ agentic なループだと、5 時間あたり約 950 (glm-5.2) vs 約 280 (kimi-k3) リクエストの差になる
@@ -76,14 +76,14 @@ fallback_providers:
 
 日次化して、朝 Slack に報告が並ぶのを見る習慣ができました。週 1 でまとめて読むより、毎日 1 行ずつの方が生活のリズムに合います。
 
-次に DM inbox。Hermes Agent の人格設定ファイル SOUL.md に、「裸のリンクだけが DM で来たら、あとで読む inbox として扱う」というルールを書きました。要約を返して、wiki の基準を満たすものだけページ化するところまでがエージェントの仕事です。ブラウザのタブへ積む代わりの置き場として使い始めています。
+次に DM inbox。Hermes Agent の人格設定ファイル SOUL.md に、「裸のリンクだけが DM で来たら、あとで読む inbox として扱う」というルールを書きました。要約を返して、wiki の基準を満たすものだけページ化するところまでがエージェントの仕事です。タブに残しておく代わりに使い始めています。
 
 最後に MoA。`/moa`と明示したときだけ発火する構成はそのままに、参照モデルを OpenRouter 従量から Go 枠内(glm-5.2 と kimi-k2.7-code、集約は deepseek-v4-pro)に差し替えました。高いから封印していた機能が、呼んでも請求の動かない機能に変わりました。
 
 ## 実感と留保
 
-コスト系記事の定番の結論は「毎日使うなら定額が得、たまにしか使わないなら従量」です。一方で、常駐エージェントは通常ユーザーの[6〜8 倍トークンを消費する](https://blog.kilo.ai/p/i-was-running-openclaw-with-my-claude)ので定額の前提を壊す、とも言われます。Anthropic が 2026 年 4 月に[Claude サブスクでの OpenClaw 利用を締め出した](https://techcrunch.com/2026/04/04/anthropic-says-claude-code-subscribers-will-need-to-pay-extra-for-openclaw-support/)のは、その帰結でした。
+よく「毎日使うなら定額が得、たまにしか使わないなら従量」と言われます。一方で、常駐エージェントは通常ユーザーの[6〜8 倍トークンを消費する](https://blog.kilo.ai/p/i-was-running-openclaw-with-my-claude)ので定額の前提を壊す、とも言われます。Anthropic が 2026 年 4 月に[Claude サブスクでの OpenClaw 利用を締め出した](https://techcrunch.com/2026/04/04/anthropic-says-claude-code-subscribers-will-need-to-pay-extra-for-openclaw-support/)のは、その帰結でした。
 
 自分の場合はどうか。$10 で従量時代より明らかに多く回せている実感があります。日次 cron と DM 対話を全部載せても、glm-5.2 の枠にはまだ遠い。DM 専業の個人エージェントは、常駐といっても消費は大したことがないのだと思います。6〜8 倍論が想定しているのは、コードを書き続ける自律エージェントの方でしょう。
 
-とはいえ移行から数日です。この生活を 1 か月続けて請求とレート枠がどうなるかは、また追記します。ローカル LLM の primary 化という[前回からの宿題](/openclaw-to-hermes-agent)も残っていますが、単価表を開かない生活は思ったより快適で、腰が重くなりつつあります。
+とはいえ移行から数日です。この生活を 1 か月続けて請求とレート枠がどうなるかは、また追記します。ローカル LLM の primary 化という[前回からの宿題](/openclaw-to-hermes-agent)も残っていますが、単価表を開かない生活は思ったより快適で、戻す気が起きません。


### PR DESCRIPTION
## 変更内容

hermes-opencode-go 記事の AI っぽい言い回し・比喩を修正。

### jaxx 指摘の 5 箇所

| 修正前 | 修正後 | 理由 |
|---|---|---|
| コストが痛かった | 高かった | 身体的痛覚のメタファー → 事実ベース |
| 財布の減る心理が邪魔 | コストが気になっていました | 抽象比喩 + 擬人化 → 平易な表現 |
| 空振りを嫌う | 空振り課金を避ける | 擬人化 → 事実ベース |
| ブラウザのタブへ積む代わりの置き場 | タブに残しておく代わりに | 抽象比喩 → 平易な表現 |
| 腰が重くなりつつあります | 戻す気が起きません | 身体的メタファー → 事実ベース |

### subagent レビューで追加修正した 3 箇所

| 修正前 | 修正後 | 理由 |
|---|---|---|
| 謳っているとおり | 書いている通り | 硬い文語 → 口語 |
| 選んだ理由は 3 つあります | にしたのは | 定型前置き → 理由を流す形 |
| 定番の結論は〜です | よく〜と言われます | 論壇的 → 口語 |

## textlint

クリーン（該当ファイル単体）